### PR TITLE
Vendor Tiny Agents from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           # This job executes repo code (cargo build/test); don't persist the
           # token in git config.
           persist-credentials: false
+          submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Build vendored code without leaving the write-capable release token
+          # in git config. The push step authenticates only its two git calls.
+          persist-credentials: false
           submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
@@ -120,8 +123,13 @@ jobs:
 
       - name: Push release commit and tag
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
+          auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 -w0)"
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
+          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${auth_header}"
           git push origin "HEAD:${GITHUB_REF_NAME}"
           git push origin "${RELEASE_TAG}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/tinyagents"]
+	path = vendor/tinyagents
+	url = https://github.com/tinyhumansai/tinyagents.git
+	branch = main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1213,10 +1214,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-bites"
@@ -1616,13 +1634,12 @@ dependencies = [
 [[package]]
 name = "tinyagents"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d9746cb9ff6f37646b2c91eebe3dee775a56083d21ed41446a54c930efaf056"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
  "futures",
+ "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "2"
 futures-timer = "3"
 futures-util = "0.3"
 getrandom = "0.4"
-tinyagents = "2.1"
+tinyagents = { version = "2.1", path = "vendor/tinyagents" }
 tracing = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time"] }
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
## Summary

- add Tiny Agents as a `vendor/tinyagents` submodule tracking its canonical `main` branch
- pin the submodule at `c9fea6358a7d0663170b55fd90af5bb309df48e5` and use it as Tiny Flows' local Cargo dependency
- initialize submodules recursively in CI and release checkouts
- retain the `2.1` version requirement so packaged Tiny Flows releases resolve the compatible crates.io dependency

## Why

Tiny Flows was still building against the older published Tiny Agents crate, so its engine dependency had drifted from current Tiny Agents development. Vendoring the repository makes the exact engine revision explicit and keeps local and CI builds aligned with Tiny Agents `main`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets`
- `cargo build --all-targets --all-features`
- `cargo test`
- `cargo test --all-features`
- `cargo llvm-cov --all-features --workspace --summary-only --fail-under-lines 90` (92.41% lines)
- `cargo package --locked`
- extension `npm run verify` (25 tests)
- extension `npm run test:e2e` (3 tests)
- extension `npm run package`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the TinyAgents component to the project and aligned builds with the vendored version.
  * Updated CI and release automation to include required submodules during checkout.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->