### PR TITLE
feat: report per-item fan-out progress

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1276,6 +1276,7 @@ fn build_graph(
                         run: &run_meta,
                         nodes: &nodes_state,
                         caps: &caps,
+                        observer: observer.as_ref(),
                         // Handed to the executor so a nested engine call (today the
                         // `sub_workflow` node) can thread this run's cancellation
                         // into its child; a plain executor never reads it.
@@ -1400,6 +1401,7 @@ fn build_graph(
                                 run: &run_meta,
                                 nodes: &nodes_state,
                                 caps: &caps,
+                                observer: observer.as_ref(),
                                 token: token.clone(),
                             };
                             let scope = crate::nodes::expr_scope(&ctx);

--- a/src/nodes/control_flow/condition.rs
+++ b/src/nodes/control_flow/condition.rs
@@ -89,6 +89,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = ConditionNode.execute(ctx).await.expect("execute");

--- a/src/nodes/control_flow/dedup.rs
+++ b/src/nodes/control_flow/dedup.rs
@@ -325,6 +325,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         DedupNode.execute(ctx).await.expect("execute")

--- a/src/nodes/control_flow/loop_node.rs
+++ b/src/nodes/control_flow/loop_node.rs
@@ -180,6 +180,7 @@ mod tests {
                 run: &Value::Null,
                 nodes: &nodes,
                 caps: &caps,
+                observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             })
             .await

--- a/src/nodes/control_flow/merge.rs
+++ b/src/nodes/control_flow/merge.rs
@@ -53,6 +53,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
 
@@ -72,6 +73,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         MergeNode.execute(ctx).await.expect("execute").items

--- a/src/nodes/control_flow/split_out.rs
+++ b/src/nodes/control_flow/split_out.rs
@@ -88,6 +88,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
 
@@ -111,6 +112,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
 
@@ -133,6 +135,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
 
@@ -152,6 +155,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         SplitOutNode.execute(ctx).await.expect("execute").items

--- a/src/nodes/control_flow/switch.rs
+++ b/src/nodes/control_flow/switch.rs
@@ -91,6 +91,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = SwitchNode.execute(ctx).await.expect("execute");
@@ -113,6 +114,7 @@ mod tests {
             run: &run,
             nodes: &nodes,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = SwitchNode.execute(ctx).await.expect("execute");

--- a/src/nodes/control_flow/transform.rs
+++ b/src/nodes/control_flow/transform.rs
@@ -86,6 +86,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         TransformNode.execute(ctx).await.expect("execute").items
@@ -111,6 +112,7 @@ mod tests {
             run: &run,
             nodes: &nodes,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = TransformNode.execute(ctx).await.expect("execute").items;

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -64,16 +64,21 @@ impl NodeExecutor for AgentNode {
             // `config.on_item_error` what a failing turn does to the batch.
             let opts = crate::nodes::map::map_options(&ctx.node.config, &ctx.node.id);
             let ctx = &ctx;
-            let (items, diagnostics) =
-                crate::nodes::map::map_items(ctx.input.len(), opts, move |index| async move {
+            let (items, diagnostics) = crate::nodes::map::map_items(
+                ctx.input.len(),
+                &ctx.node.id,
+                ctx.observer,
+                opts,
+                move |index| async move {
                     let (cfg, diags) = crate::nodes::resolve_config_traced_for_item(
                         ctx,
                         ctx.input[index].json.clone(),
                     );
                     let item = run_turn(ctx, &cfg).await?;
                     Ok((item, diags))
-                })
-                .await?;
+                },
+            )
+            .await?;
             return Ok(NodeOutput::main(items).with_diagnostics(diagnostics));
         }
 
@@ -291,6 +296,7 @@ mod tests {
                 run: &run_meta,
                 nodes: &Value::Null,
                 caps: &caps,
+                observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             })
             .await
@@ -307,6 +313,7 @@ mod tests {
                 run: &run_meta,
                 nodes: &Value::Null,
                 caps: &caps,
+                observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             })
             .await
@@ -329,6 +336,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = AgentNode.execute(ctx).await.expect("execute");
@@ -355,6 +363,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = AgentNode.execute(ctx).await.expect("execute");
@@ -373,6 +382,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = AgentNode.execute(ctx).await.expect("execute");
@@ -397,6 +407,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = AgentNode.execute(ctx).await.expect("execute");
@@ -425,6 +436,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         AgentNode
@@ -586,6 +598,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let err = AgentNode

--- a/src/nodes/integration/code.rs
+++ b/src/nodes/integration/code.rs
@@ -109,6 +109,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         CodeNode.execute(ctx).await.expect("execute").items

--- a/src/nodes/integration/http_request.rs
+++ b/src/nodes/integration/http_request.rs
@@ -38,16 +38,21 @@ impl NodeExecutor for HttpRequestNode {
             // once (default 1 — sequential, as before).
             let opts = crate::nodes::map::map_options(&ctx.node.config, &ctx.node.id);
             let ctx = &ctx;
-            let (items, diagnostics) =
-                crate::nodes::map::map_items(ctx.input.len(), opts, move |index| async move {
+            let (items, diagnostics) = crate::nodes::map::map_items(
+                ctx.input.len(),
+                &ctx.node.id,
+                ctx.observer,
+                opts,
+                move |index| async move {
                     let (cfg, diags) = crate::nodes::resolve_config_traced_for_item(
                         ctx,
                         ctx.input[index].json.clone(),
                     );
                     let response = request(ctx, &cfg).await?;
                     Ok((Item::new(envelope::wrap(response)), diags))
-                })
-                .await?;
+                },
+            )
+            .await?;
             Ok(NodeOutput::main(items).with_diagnostics(diagnostics))
         } else {
             let (cfg, diagnostics) = crate::nodes::resolve_config_traced(&ctx);
@@ -139,6 +144,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = HttpRequestNode.execute(ctx).await.expect("execute");
@@ -176,6 +182,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = HttpRequestNode.execute(ctx).await.expect("execute");
@@ -204,6 +211,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = HttpRequestNode.execute(ctx).await.expect("execute");

--- a/src/nodes/integration/memory.rs
+++ b/src/nodes/integration/memory.rs
@@ -228,16 +228,21 @@ impl NodeExecutor for MemoryNode {
             // at once (default 1 — sequential, as before).
             let opts = crate::nodes::map::map_options(&ctx.node.config, &ctx.node.id);
             let ctx = &ctx;
-            let (items, diagnostics) =
-                crate::nodes::map::map_items(ctx.input.len(), opts, move |index| async move {
+            let (items, diagnostics) = crate::nodes::map::map_items(
+                ctx.input.len(),
+                &ctx.node.id,
+                ctx.observer,
+                opts,
+                move |index| async move {
                     let (cfg, diags) = crate::nodes::resolve_config_traced_for_item(
                         ctx,
                         ctx.input[index].json.clone(),
                     );
                     let result = call_provider(ctx, &cfg).await?;
                     Ok((Item::new(envelope::wrap(result)), diags))
-                })
-                .await?;
+                },
+            )
+            .await?;
             tracing::debug!(
                 node = %ctx.node.id,
                 emitted = items.len(),
@@ -404,6 +409,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = MemoryNode.execute(ctx).await.expect("execute");
@@ -459,6 +465,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = MemoryNode.execute(ctx).await.expect("execute");
@@ -478,6 +485,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let err = MemoryNode
@@ -504,6 +512,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let err = MemoryNode
@@ -547,6 +556,7 @@ mod tests {
                 run: &run_meta,
                 nodes: &Value::Null,
                 caps: &caps,
+                observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             };
             let err = MemoryNode
@@ -572,6 +582,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let err = MemoryNode
@@ -597,6 +608,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let err = MemoryNode
@@ -626,6 +638,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = MemoryNode.execute(ctx).await.expect("execute");

--- a/src/nodes/integration/output_parser.rs
+++ b/src/nodes/integration/output_parser.rs
@@ -82,6 +82,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = OutputParserNode.execute(ctx).await.expect("execute");
@@ -110,6 +111,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         OutputParserNode.execute(ctx).await.expect("execute").items
@@ -173,6 +175,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         OutputParserNode.execute(ctx).await.map(|o| o.items)

--- a/src/nodes/integration/shell_tests.rs
+++ b/src/nodes/integration/shell_tests.rs
@@ -36,6 +36,7 @@ async fn execute_with(caps: Capabilities, config: Value) -> Result<NodeOutput> {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         })
         .await

--- a/src/nodes/integration/sub_workflow.rs
+++ b/src/nodes/integration/sub_workflow.rs
@@ -177,8 +177,12 @@ impl NodeExecutor for SubWorkflowNode {
         if per_item {
             let opts = crate::nodes::map::map_options(&ctx.node.config, &ctx.node.id);
             let ctx = &ctx;
-            let (items, _) =
-                crate::nodes::map::map_items(ctx.input.len(), opts, move |index| async move {
+            let (items, _) = crate::nodes::map::map_items(
+                ctx.input.len(),
+                &ctx.node.id,
+                ctx.observer,
+                opts,
+                move |index| async move {
                     let item = &ctx.input[index];
                     // Each child resolves `workflow_id` against *its own* item,
                     // so `=item.x` addresses the element this run is for, and
@@ -193,8 +197,9 @@ impl NodeExecutor for SubWorkflowNode {
                         .await?
                         .unwrap_or_else(|| crate::data::Item::new(Value::Null));
                     Ok((child, vec![]))
-                })
-                .await?;
+                },
+            )
+            .await?;
             // Parent-initiated cancel: wind down with no output, mirroring the
             // top-level cancelled-node contract. `ctx.token` is a one-way flag,
             // so if any child wound down (returned `None`) it is set here; the
@@ -415,6 +420,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         SubWorkflowNode
@@ -438,6 +444,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         SubWorkflowNode.execute(ctx).await.expect("execute")
@@ -702,6 +709,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         SubWorkflowNode.execute(ctx).await

--- a/src/nodes/integration/tool_call.rs
+++ b/src/nodes/integration/tool_call.rs
@@ -47,16 +47,21 @@ impl NodeExecutor for ToolCallNode {
             // flight at once (default 1 — sequential, as before).
             let opts = crate::nodes::map::map_options(&ctx.node.config, &ctx.node.id);
             let ctx = &ctx;
-            let (items, diagnostics) =
-                crate::nodes::map::map_items(ctx.input.len(), opts, move |index| async move {
+            let (items, diagnostics) = crate::nodes::map::map_items(
+                ctx.input.len(),
+                &ctx.node.id,
+                ctx.observer,
+                opts,
+                move |index| async move {
                     let (cfg, diags) = crate::nodes::resolve_config_traced_for_item(
                         ctx,
                         ctx.input[index].json.clone(),
                     );
                     let result = invoke(ctx, &cfg).await?;
                     Ok((Item::new(envelope::wrap(result)), diags))
-                })
-                .await?;
+                },
+            )
+            .await?;
             Ok(NodeOutput::main(items).with_diagnostics(diagnostics))
         } else {
             // Single invocation against the first-item scope (or empty input).
@@ -174,6 +179,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let err = ToolCallNode
@@ -200,6 +206,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = ToolCallNode.execute(ctx).await.expect("execute");
@@ -225,6 +232,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = ToolCallNode.execute(ctx).await.expect("execute");
@@ -246,6 +254,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = ToolCallNode.execute(ctx).await.expect("execute");
@@ -273,6 +282,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = ToolCallNode.execute(ctx).await.expect("execute");
@@ -301,6 +311,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let out = ToolCallNode.execute(ctx).await.expect("execute");

--- a/src/nodes/map.rs
+++ b/src/nodes/map.rs
@@ -203,6 +203,8 @@ fn error_item(message: &str) -> Item {
 /// error non-deterministic across runs. The other two policies never error.
 pub(crate) async fn map_items<F, Fut>(
     total: usize,
+    node_id: &str,
+    observer: &dyn crate::observability::RunObserver,
     opts: MapOptions,
     f: F,
 ) -> Result<(Vec<Item>, Vec<NullResolution>)>
@@ -218,10 +220,16 @@ where
         opts.concurrency
     };
 
-    // Each future carries its input index so completions can be re-slotted.
+    // Observer calls live inside the future so `buffer_unordered` only reports
+    // work as started when a concurrency slot actually begins polling it.
     let mut stream = futures_util::stream::iter((0..total).map(|index| {
         let fut = f(index);
-        async move { (index, fut.await) }
+        async move {
+            observer.on_item_start(node_id, index, total);
+            let result = fut.await;
+            observer.on_item_finish(node_id, index, total, result.is_ok());
+            (index, result)
+        }
     }))
     .buffer_unordered(in_flight);
 
@@ -335,6 +343,8 @@ mod tests {
         // Later items finish first: item 0 yields the most, item 4 the least.
         let (out, _) = map_items(
             input.len(),
+            "n",
+            &crate::observability::NoopObserver,
             opts(0, ItemErrorPolicy::Collect),
             |index| async move {
                 for _ in 0..(5 - index) * 4 {
@@ -361,6 +371,8 @@ mod tests {
         let input = &input;
         let (out, _) = map_items(
             input.len(),
+            "n",
+            &crate::observability::NoopObserver,
             opts(1, ItemErrorPolicy::Collect),
             move |index| {
                 let g = g.clone();
@@ -387,6 +399,8 @@ mod tests {
         let input = &input;
         let (out, _) = map_items(
             input.len(),
+            "n",
+            &crate::observability::NoopObserver,
             opts(4, ItemErrorPolicy::Collect),
             move |index| {
                 let g = g.clone();
@@ -418,6 +432,8 @@ mod tests {
         let input = &input;
         let (out, _) = map_items(
             input.len(),
+            "n",
+            &crate::observability::NoopObserver,
             opts(0, ItemErrorPolicy::Collect),
             move |index| {
                 let g = g.clone();
@@ -442,6 +458,8 @@ mod tests {
         let input = &input;
         let (out, _) = map_items(
             input.len(),
+            "n",
+            &crate::observability::NoopObserver,
             opts(0, ItemErrorPolicy::Collect),
             |index| async move {
                 if index == 2 {
@@ -473,6 +491,8 @@ mod tests {
         let input = &input;
         let (out, _) = map_items(
             input.len(),
+            "n",
+            &crate::observability::NoopObserver,
             opts(0, ItemErrorPolicy::Skip),
             |index| async move {
                 if index % 2 == 0 {
@@ -499,6 +519,8 @@ mod tests {
         // must win, so the reported error is item 1's.
         let err = map_items(
             input.len(),
+            "n",
+            &crate::observability::NoopObserver,
             opts(0, ItemErrorPolicy::FailFast),
             |index| async move {
                 if index == 4 {
@@ -522,9 +544,13 @@ mod tests {
 
     #[tokio::test]
     async fn empty_input_yields_no_items_and_no_error() {
-        let (out, diags) = map_items(0, opts(0, ItemErrorPolicy::Collect), |_| async {
-            unreachable!("no items to map")
-        })
+        let (out, diags) = map_items(
+            0,
+            "n",
+            &crate::observability::NoopObserver,
+            opts(0, ItemErrorPolicy::Collect),
+            |_| async { unreachable!("no items to map") },
+        )
         .await
         .expect("map");
         assert!(out.is_empty());
@@ -536,6 +562,8 @@ mod tests {
         let input = items(3);
         let (_, diags) = map_items(
             input.len(),
+            "n",
+            &crate::observability::NoopObserver,
             opts(0, ItemErrorPolicy::Collect),
             |index| async move {
                 Ok((

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -39,6 +39,8 @@ pub struct NodeContext<'a> {
     pub nodes: &'a Value,
     /// Host-provided capabilities.
     pub caps: &'a Capabilities,
+    /// Host observer used to report per-item fan-out progress.
+    pub observer: &'a dyn crate::observability::RunObserver,
     /// The run's cooperative-cancellation token (see
     /// [`crate::engine::CancellationToken`]). An **owned clone** of the run
     /// token, not a borrow — an executor that spawns nested engine work (today
@@ -440,6 +442,7 @@ mod tests {
                     run: &run,
                     nodes: &Value::Null,
                     caps: &caps,
+                    observer: &crate::observability::NoopObserver,
                     token: crate::engine::CancellationToken::new(),
                 })
                 .await;
@@ -464,6 +467,7 @@ mod tests {
                 run: &run,
                 nodes: &Value::Null,
                 caps: &caps,
+                observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             })
             .await
@@ -493,6 +497,7 @@ mod tests {
             run: &run,
             nodes: &nodes_state,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let scope = expr_scope(&ctx);
@@ -523,6 +528,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps: &caps,
+            observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
         let scope = expr_scope(&ctx);

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -159,6 +159,25 @@ pub trait RunObserver: Send + Sync {
         let _ = step;
     }
 
+    /// Called as each item of a per-item node starts.
+    ///
+    /// `index` is the stable input position and `total` is the batch size. The
+    /// callbacks are silent for nodes that execute once, so hosts can use them
+    /// specifically to render fan-out work in flight.
+    fn on_item_start(&self, node_id: &str, index: usize, total: usize) {
+        let _ = (node_id, index, total);
+    }
+
+    /// Called as each item of a per-item node settles.
+    ///
+    /// `ok` describes that item's work before `on_item_error` policy is applied;
+    /// a collected item error therefore reports `false` even when the overall
+    /// node succeeds. Fail-fast cancellation may drop started items before this
+    /// callback can run.
+    fn on_item_finish(&self, node_id: &str, index: usize, total: usize, ok: bool) {
+        let _ = (node_id, index, total, ok);
+    }
+
     /// Called once, after the run settles, with the assembled [`Run`] record.
     fn on_run_finish(&self, run: &Run) {
         let _ = run;
@@ -190,6 +209,8 @@ mod tests {
             duration_ms: 0,
             diagnostics: Vec::new(),
         });
+        observer.on_item_start("n", 0, 1);
+        observer.on_item_finish("n", 0, 1, true);
         observer.on_run_finish(&Run {
             id: "run-0".to_string(),
             status: RunStatus::Completed,

--- a/tests/per_item_fanout_e2e.rs
+++ b/tests/per_item_fanout_e2e.rs
@@ -23,6 +23,7 @@ use tinyflows::caps::{Capabilities, LlmProvider};
 use tinyflows::compiler::compile;
 use tinyflows::engine::run;
 use tinyflows::model::{Edge, Node, NodeKind, TriggerKind, WorkflowGraph};
+use tinyflows::observability::RunObserver;
 
 /// Builds a node with the given id, kind, and config (no ports, no position).
 fn node(id: &str, kind: NodeKind, config: Value) -> Node {
@@ -294,4 +295,75 @@ async fn a_fanned_out_batch_can_opt_back_into_failing_the_node() {
         err.to_string().contains("gamma"),
         "expected the failing item's error, got: {err}"
     );
+}
+
+#[derive(Default)]
+struct ItemObserver {
+    starts: std::sync::Mutex<Vec<(String, usize, usize)>>,
+    finishes: std::sync::Mutex<Vec<(String, usize, usize, bool)>>,
+    live: AtomicUsize,
+    peak_live: AtomicUsize,
+}
+
+impl RunObserver for ItemObserver {
+    fn on_item_start(&self, node_id: &str, index: usize, total: usize) {
+        self.starts
+            .lock()
+            .unwrap()
+            .push((node_id.to_string(), index, total));
+        let live = self.live.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak_live.fetch_max(live, Ordering::SeqCst);
+    }
+
+    fn on_item_finish(&self, node_id: &str, index: usize, total: usize, ok: bool) {
+        self.live.fetch_sub(1, Ordering::SeqCst);
+        self.finishes
+            .lock()
+            .unwrap()
+            .push((node_id.to_string(), index, total, ok));
+    }
+}
+
+#[tokio::test]
+async fn a_real_run_reports_each_fanned_out_item_to_the_observer() {
+    let watcher = Arc::new(ItemObserver::default());
+    let observer: Arc<dyn RunObserver> = watcher.clone();
+    let graph = fanout_graph(json!({
+        "prompt": "=item.name",
+        "execution": "per_item",
+        "concurrency": 3,
+    }));
+    let compiled = compile(&graph).expect("compile");
+
+    tinyflows::engine::run_with_observer(
+        &compiled,
+        topics(),
+        &caps_with(Arc::new(ConcurrencyProbe::default())),
+        &observer,
+    )
+    .await
+    .expect("run");
+
+    let starts = watcher.starts.lock().unwrap().clone();
+    let finishes = watcher.finishes.lock().unwrap().clone();
+    assert_eq!(starts.len(), 5);
+    assert_eq!(finishes.len(), 5);
+    assert!(
+        starts
+            .iter()
+            .all(|(node, _, total)| node == "work" && *total == 5)
+    );
+    assert!(
+        finishes
+            .iter()
+            .all(|(node, _, total, ok)| node == "work" && *total == 5 && *ok)
+    );
+    let mut indices = starts
+        .iter()
+        .map(|(_, index, _)| *index)
+        .collect::<Vec<_>>();
+    indices.sort_unstable();
+    assert_eq!(indices, [0, 1, 2, 3, 4]);
+    let peak = watcher.peak_live.load(Ordering::SeqCst);
+    assert!(peak > 1 && peak <= 3, "unexpected live-worker peak: {peak}");
 }


### PR DESCRIPTION
## What changed

Adds RunObserver callbacks for per-item start and finish events, including stable input index, batch size, and item success. Threads the observer through node execution and emits callbacks only when bounded-concurrency work actually starts.

## Why

The last two commits on the old parallel-fanout branch were added after PR #26 merged, so hosts could only observe the enclosing node step and not the individual workers in flight. This ports that intent onto the current cancellation-aware engine.

## Validation

- cargo test --all-features --test per_item_fanout_e2e
- cargo test --all-features nodes::map
- cargo test --all-features observability::tests