### PR TITLE
feat(agent): configurable agents — dynamic context, tools, agent types, model/provider

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/tinyagents"]
+	path = vendor/tinyagents
+	url = https://github.com/tinyhumansai/tinyagents.git
+	branch = main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Configurable agents.** An `agent` node can now be given dynamic context,
+  an explicit tool allow-list, a model and provider, a working directory,
+  advisory limits, and arbitrary harness metadata — while the agent
+  *implementation* stays entirely with the embedding harness. tinyflows runs no
+  agentic loop: it assembles a typed `caps::AgentRunRequest` and the harness
+  executes it.
+  - `WorkflowGraph::agents`: a top-level registry of reusable
+    `model::AgentDefinition`s (id, name, description, instructions, model,
+    provider, working_dir, tools, context, limits, metadata), mirroring
+    `inputs`. A node's `agent_ref` resolves here first, then against the
+    harness's registry, then passes through as a bare id.
+  - New `agent` node config keys, all optional: `instructions`, `model`,
+    `provider`, `working_dir`, `context`, `limits`, `metadata` (`prompt`,
+    `agent_ref`, `tools`, `output_parser`, `connection_ref` keep their meaning).
+    A node may only **narrow** its agent definition — instructions append,
+    context appends, tools intersect, limits take the lower bound.
+  - `model::ContextSource`: declarative dynamic context — `text` (literal or
+    `=`-expression), `items`, `memory` and `flavour` (via the existing
+    `MemoryProvider`), and `host` (expanded by the harness). An unresolvable
+    source fails the node unless it sets `optional: true`.
+  - `model::AgentLimits`: `max_steps`, `max_tool_calls`, `agent_timeout_secs`
+    (whole run) and `tool_timeout_secs` (per tool call).
+  - `AgentRunner` gains four **defaulted** methods — `run`, `resolve_agent`,
+    `list_agents`, `resolve_context`, `resolve_tools` — plus the value types
+    `AgentRunRequest`, `AgentRunOutcome`, `StopReason`, `ContextBlock`,
+    `ToolDescriptor`, `AgentRunIdentity`, `AgentModelSelection`, `AgentUsage`.
+  - `StopReason` distinguishes `Finished` from `LimitStop` and `Paused`, so a
+    partial or human-blocked run is no longer indistinguishable from an answer.
+    Surfaced on the item envelope's new `meta` key as `=item.meta.stop`.
+  - `validate::unresolved_agent_refs` reports refs the graph does not declare,
+    for hosts that want author-time resolution against their own registry.
+  - Author-time validation: duplicate agent ids, literal-only `agent_ref` /
+    tool `slug` / tool `connection_ref` / memory `scope`, trailing-`.*`-only
+    tool patterns, positive limits, and a node that tries to widen an in-graph
+    agent's tool grants.
+  - Mocks: `MockAgentHarness` (typed seam), `MockLimitedAgentRunner`,
+    `MockPausingAgentRunner`.
+
+  **This release is additive.** `AgentRunner::run_agent` is unchanged and
+  remains the trait's only required method; the default `run` forwards the
+  node's resolved config to it verbatim, so a host written against the previous
+  release compiles untouched and behaves byte-identically. `Capabilities` gains
+  no fields, and the item envelope's `json` / `text` / `raw` are unchanged. The
+  only source-level change is the new `agents` field on `WorkflowGraph` (and
+  `agents` on `NodeContext`): JSON round-trips unaffected, but code
+  constructing either by exhaustive struct literal needs `..Default::default()`
+  or the new field. To move off the shim, override `AgentRunner::run` and map
+  your harness's real stop reason onto `StopReason` — leaving it defaulted
+  reports every run as `Finished`.
+
 - A `shell` node kind that runs a shell script — inline via `config.source` or
   from a file via `config.script_path` — with an optional `interpreter`
   (`sh`/`bash`), `cwd`, and `env`. A non-zero exit fails the step; a successful

--- a/src/caps/agent.rs
+++ b/src/caps/agent.rs
@@ -667,7 +667,13 @@ mod tests {
 
     #[tokio::test]
     async fn the_default_resolvers_report_absence_not_failure() {
-        assert!(LegacyRunner.resolve_agent("anything").await.unwrap().is_none());
+        assert!(
+            LegacyRunner
+                .resolve_agent("anything")
+                .await
+                .unwrap()
+                .is_none()
+        );
         assert!(LegacyRunner.list_agents().await.unwrap().is_empty());
         assert!(
             LegacyRunner
@@ -714,18 +720,28 @@ mod tests {
 
         let from_string = AgentRunOutcome::finished(json!("just prose"));
         assert_eq!(from_string.text.as_deref(), Some("just prose"));
-        assert_eq!(from_string.json, Value::Null, "a scalar carries no structure");
+        assert_eq!(
+            from_string.json,
+            Value::Null,
+            "a scalar carries no structure"
+        );
     }
 
     #[test]
     fn stop_reasons_have_stable_wire_names() {
         assert_eq!(StopReason::Finished.as_str(), "finished");
         assert_eq!(
-            StopReason::LimitStop { limit: "max_steps".into() }.as_str(),
+            StopReason::LimitStop {
+                limit: "max_steps".into()
+            }
+            .as_str(),
             "limit_stop"
         );
         assert_eq!(
-            serde_json::to_value(StopReason::LimitStop { limit: "max_steps".into() }).unwrap(),
+            serde_json::to_value(StopReason::LimitStop {
+                limit: "max_steps".into()
+            })
+            .unwrap(),
             json!({ "stop": "limit_stop", "limit": "max_steps" })
         );
     }

--- a/src/caps/agent.rs
+++ b/src/caps/agent.rs
@@ -240,6 +240,19 @@ pub struct AgentRunRequest {
     /// run acts as.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connection_ref: Option<String>,
+    /// Working directory the agent should run in, when it runs somewhere with a
+    /// filesystem. `None` means the harness's default applies.
+    ///
+    /// Surfaced here as well as on
+    /// [`agent.working_dir`](crate::model::AgentDefinition::working_dir)
+    /// because a harness reaching for it should not have to know whether the
+    /// definition or the node supplied it — this is the merged, effective value.
+    ///
+    /// **Untrusted authoring input**: the engine never touches the filesystem
+    /// and never checks that this exists or is permitted. Validate it against
+    /// your own allowed roots before handing it to a process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
     /// Run identity, for host-side tracing and budgeting.
     #[serde(default)]
     pub identity: AgentRunIdentity,

--- a/src/caps/agent.rs
+++ b/src/caps/agent.rs
@@ -1,0 +1,718 @@
+//! The `agent` node's host capability: running a host-owned agent.
+//!
+//! tinyflows implements **no agentic loop**. The model↔tool loop, the
+//! transcript, the budget, and the prompt assembly all belong to the embedding
+//! harness. This crate's contribution is the *assembly*: turning an author's
+//! declarative [`AgentDefinition`], context sources, and tool grants into one
+//! inert, fully-resolved [`AgentRunRequest`], and turning the harness's
+//! [`AgentRunOutcome`] back into the stable `{ json, text, raw, meta }` item
+//! envelope.
+//!
+//! ```text
+//!   graph `agents` registry ─┐
+//!   node config             ─┼─► merge ─► resolve context ─► resolve tools
+//!   AgentRunner::resolve_*  ─┘                                     │
+//!                                                                  ▼
+//!                        AgentRunOutcome ◄── AgentRunner::run(AgentRunRequest)
+//! ```
+//!
+//! ## Everything new here is additive
+//!
+//! [`AgentRunner::run_agent`] is unchanged and remains the trait's only required
+//! method, so a host written against the previous release compiles and behaves
+//! identically: the default [`run`](AgentRunner::run) replays exactly the call
+//! it made before. A harness opts into richer agents by overriding the defaulted
+//! methods, one at a time.
+//!
+//! ## Absence is not failure
+//!
+//! [`resolve_agent`](AgentRunner::resolve_agent) and
+//! [`resolve_context`](AgentRunner::resolve_context) return `Ok(None)` for an
+//! id they do not recognize. That is a **normal outcome**, not a soft error: a
+//! host's catalogue is data and legitimately names things absent from a given
+//! build, and the caller has a fallback. `Err` is reserved for a genuine failure
+//! to *answer* — a broken store, a lost connection.
+//!
+//! Every value type in this module is `serde` + `std` only, so a host can write
+//! an adapter against it without linking the engine.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::error::Result;
+use crate::model::{AgentDefinition, ToolGrant};
+
+/// Which model, on which provider, an agent run should use.
+///
+/// Both fields are opaque to the engine and both may be `None`, meaning "no
+/// author preference — the harness's default applies". They are carried
+/// separately rather than as one composite string so a harness routing the same
+/// model through different providers need not parse them apart.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct AgentModelSelection {
+    /// Model id, e.g. `"claude-opus-5"` or a host alias.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Provider id, e.g. `"anthropic"`, a gateway name, or a host routing key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+}
+
+impl AgentModelSelection {
+    /// Whether the author expressed no preference at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.model.is_none() && self.provider.is_none()
+    }
+}
+
+/// What the agent is being asked to do.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct AgentInput {
+    /// The task text (the node's `prompt`), with `=`-expressions resolved.
+    ///
+    /// An empty string is legal: a run driven entirely by `data` and context is
+    /// a real case.
+    #[serde(default)]
+    pub text: String,
+    /// The `json` payload of each of the node's input items, in order.
+    ///
+    /// Carried alongside `text` rather than stringified into it, so a harness
+    /// with structured input support need not parse prose back apart, and one
+    /// without it can serialize this however it likes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub data: Vec<Value>,
+}
+
+/// One resolved block of agent context, ready to hand to the harness.
+///
+/// The engine resolves each declared
+/// [`ContextSource`](crate::model::ContextSource) in declaration order and
+/// passes the list through. It never reorders, merges, de-duplicates, ranks, or
+/// truncates blocks — composing them into a prompt is the harness's job,
+/// because the harness owns the loop.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ContextBlock {
+    /// The authored label, or the generated `"context_<n>"`.
+    pub label: String,
+    /// The wire name of the source kind this came from (`"text"`, `"items"`,
+    /// `"memory"`, `"flavour"`, `"host"`), so a harness can format a memory
+    /// recall differently from literal text without re-deriving where it came
+    /// from.
+    pub source_kind: String,
+    /// Human-readable body, when the source produced prose.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Structured body, when the source produced data — a memory `results`
+    /// array, a host record. [`Value::Null`] when there is none.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub data: Value,
+}
+
+impl ContextBlock {
+    /// A prose block.
+    #[must_use]
+    pub fn text(label: impl Into<String>, source_kind: &str, text: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            source_kind: source_kind.to_string(),
+            text: Some(text.into()),
+            data: Value::Null,
+        }
+    }
+
+    /// A structured block.
+    #[must_use]
+    pub fn data(label: impl Into<String>, source_kind: &str, data: Value) -> Self {
+        Self {
+            label: label.into(),
+            source_kind: source_kind.to_string(),
+            text: None,
+            data,
+        }
+    }
+}
+
+/// A concrete tool the harness may offer the model this run.
+///
+/// The discovery half [`ToolInvoker`](crate::caps::ToolInvoker) never had: a
+/// slug plus enough metadata for a model to choose it. Produced from an
+/// author's [`ToolGrant`]s by
+/// [`AgentRunner::resolve_tools`](AgentRunner::resolve_tools).
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ToolDescriptor {
+    /// The slug the harness would pass to
+    /// [`ToolInvoker::invoke`](crate::caps::ToolInvoker::invoke).
+    ///
+    /// Concrete when a harness expanded a grant; a harness that does not expand
+    /// receives the author's grant verbatim, patterns included.
+    pub slug: String,
+    /// Display name, when the harness knows one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// What the tool does, for the model's benefit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// JSON Schema for the tool's arguments. `None` means "undescribed", not
+    /// "takes no arguments".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<Value>,
+    /// The trusted connection reference this tool must be called with, carried
+    /// down from the grant or the node. Never model-supplied.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_ref: Option<String>,
+}
+
+impl ToolDescriptor {
+    /// The undescribed descriptor a [`ToolGrant`] becomes when no harness
+    /// expands it: the slug and its trusted connection reference, nothing more.
+    #[must_use]
+    pub fn from_grant(grant: &ToolGrant, fallback_conn: Option<&str>) -> Self {
+        Self {
+            slug: grant.slug.clone(),
+            name: None,
+            description: None,
+            input_schema: None,
+            connection_ref: grant
+                .connection_ref
+                .clone()
+                .or_else(|| fallback_conn.map(str::to_string)),
+        }
+    }
+}
+
+/// Who is running, for host-side tracing, budgeting, and rate limiting.
+///
+/// Informational to the engine — nothing here is enforced, and a harness may
+/// ignore all of it. It exists because a harness that cannot attribute an agent
+/// run to a workflow run cannot bill it, trace it, or cap it.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct AgentRunIdentity {
+    /// The enclosing workflow run's id, when the run has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    /// The workflow's id, when the graph declares one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+    /// The graph id of the `agent` node issuing this request. Stable across
+    /// renames, so it is the right key for a per-node budget.
+    pub node_id: String,
+    /// `sub_workflow` nesting depth, `0` at the top level. A harness budgeting
+    /// recursive workflows needs this to tell a runaway chain from a wide one.
+    #[serde(default)]
+    pub depth: u32,
+    /// Index of the input item this run is for under `per_item` execution;
+    /// `None` for a single `once` turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_index: Option<usize>,
+}
+
+/// One `agent` node's run request: everything the harness needs, fully
+/// resolved.
+///
+/// By the time a harness sees one, every `=`-expression is evaluated, every
+/// context block is materialized, and every tool grant has been offered for
+/// expansion. The harness resolves nothing further except its own credentials.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentRunRequest {
+    /// The merged, fully-resolved agent type: id, instructions, limits, and the
+    /// grants and context sources it was defined with.
+    pub agent: AgentDefinition,
+    /// Which model, on which provider.
+    #[serde(default)]
+    pub model: AgentModelSelection,
+    /// What this run is being asked to do.
+    #[serde(default)]
+    pub input: AgentInput,
+    /// Resolved context, in declaration order — the definition's blocks first,
+    /// then the node's. Empty is normal.
+    #[serde(default)]
+    pub context: Vec<ContextBlock>,
+    /// The tools this run may use, already narrowed by any node-level
+    /// allow-list.
+    ///
+    /// An empty vec means **no tools**, not "harness default"; a harness must
+    /// not widen it.
+    #[serde(default)]
+    pub tools: Vec<ToolDescriptor>,
+    /// The opaque, host-managed connection reference naming the account this
+    /// run acts as.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_ref: Option<String>,
+    /// Run identity, for host-side tracing and budgeting.
+    #[serde(default)]
+    pub identity: AgentRunIdentity,
+    /// Free-form passthrough: the agent definition's `metadata` with the node's
+    /// merged over it. The engine never interprets it.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub metadata: Map<String, Value>,
+    /// The schema the node's `output_parser` sub-port will validate against.
+    ///
+    /// **Advisory.** The engine still validates and repairs the outcome itself,
+    /// so a harness may ignore this. It is forwarded because a harness with
+    /// native structured output gets the right shape on the first try instead of
+    /// paying for a repair round-trip.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<Value>,
+    /// The node's resolved config, verbatim.
+    ///
+    /// This is what the default [`AgentRunner::run`] forwards to
+    /// [`run_agent`](AgentRunner::run_agent), which is how a host written
+    /// against the previous release keeps receiving byte-identical input. It is
+    /// also the escape hatch for any config key this struct does not model.
+    #[serde(default)]
+    pub config: Value,
+}
+
+/// Why a host-owned agent loop stopped.
+///
+/// The reason a typed outcome is worth having. With a bare `Value` return, an
+/// agent that finished, one that stopped a step short of the answer, and one
+/// waiting on a human are all indistinguishable — and the workflow marches
+/// downstream with a partial answer in every case. Keeping the stop reason out
+/// of the `Result` channel (rather than reporting a limit or a pause as an
+/// error) is the same split [`ShellRunner`](crate::caps::ShellRunner) makes by
+/// reporting a non-zero exit through `exit_code` instead of `Err`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "stop", rename_all = "snake_case")]
+pub enum StopReason {
+    /// The agent produced a final answer. The only reason a downstream node
+    /// should treat the outcome as complete.
+    Finished,
+    /// The loop hit a cap and stopped cleanly, keeping what it produced. The
+    /// outcome is **partial**: real, usable, and not the whole answer.
+    LimitStop {
+        /// Host-defined name of the cap that fired (`"max_steps"`,
+        /// `"token_budget"`, `"wall_clock"`).
+        ///
+        /// A free string, not an enum: the engine branches on *whether* a limit
+        /// fired, never on which, and an enum here would mint a taxonomy this
+        /// crate cannot keep current with any harness's budget model.
+        limit: String,
+    },
+    /// The loop latched a pause and is **resumable, not finished** — the
+    /// harness still holds the transcript.
+    ///
+    /// The engine does not yet route a pause into its checkpoint/resume
+    /// machinery: an `agent` node that receives this fails with a clear
+    /// [`EngineError::Capability`](crate::error::EngineError::Capability)
+    /// naming the node and reason. The variant exists now so a harness can
+    /// never *conflate* a pause with a finish, and so no wire type has to
+    /// change when resume support lands.
+    Paused {
+        /// Opaque host handle for the paused run — a session id, a checkpoint
+        /// key — which the harness will need echoed back to resume it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        token: Option<String>,
+        /// Host-defined reason (`"tool_approval"`, `"clarifying_question"`),
+        /// surfaced to whoever is being asked.
+        reason: String,
+        /// What the human must decide on. Opaque to the engine.
+        #[serde(default, skip_serializing_if = "Value::is_null")]
+        payload: Value,
+    },
+}
+
+impl StopReason {
+    /// The `snake_case` wire name of this reason, as it appears on the item
+    /// envelope's `meta.stop`.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Finished => "finished",
+            Self::LimitStop { .. } => "limit_stop",
+            Self::Paused { .. } => "paused",
+        }
+    }
+}
+
+/// Token and step accounting for one agent run, as the harness reports it.
+///
+/// The engine neither aggregates nor enforces these; it forwards them onto the
+/// item envelope's `meta.usage` for cost-aware workflows to read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct AgentUsage {
+    /// Prompt tokens consumed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<u64>,
+    /// Completion tokens produced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<u64>,
+    /// Model↔tool iterations the loop performed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub steps: Option<u32>,
+    /// Tool invocations the loop performed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<u32>,
+}
+
+/// What a host-owned agent run produced.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentRunOutcome {
+    /// Why the loop stopped. **Read this before the payload.**
+    pub stop: StopReason,
+    /// The agent's prose answer, when it produced one. Lands at the item
+    /// envelope's `text`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// The structured result, when the agent produced one. Lands at the
+    /// envelope's `json`, after the `output_parser` sub-port if one is
+    /// configured. [`Value::Null`] when the agent answered only in prose.
+    #[serde(default)]
+    pub json: Value,
+    /// The harness's native payload, verbatim. Lands at the envelope's `raw`,
+    /// and is the escape hatch for anything this struct does not model.
+    #[serde(default)]
+    pub raw: Value,
+    /// Optional usage figures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<AgentUsage>,
+}
+
+impl AgentRunOutcome {
+    /// A [`Finished`](StopReason::Finished) outcome built from a harness's
+    /// native `value`, deriving `json` and `text` the way the engine's envelope
+    /// does: `json` is the value when it is an object or array, and `text` is
+    /// the value when it is a string, else its `text` field.
+    ///
+    /// This is what the default [`AgentRunner::run`] wraps a legacy
+    /// [`run_agent`](AgentRunner::run_agent) return in, and the shorthand a
+    /// simple adapter wants.
+    ///
+    /// ```
+    /// use tinyflows::caps::{AgentRunOutcome, StopReason};
+    /// use serde_json::json;
+    ///
+    /// let outcome = AgentRunOutcome::finished(json!({ "text": "done", "n": 1 }));
+    /// assert_eq!(outcome.stop, StopReason::Finished);
+    /// assert_eq!(outcome.text.as_deref(), Some("done"));
+    /// assert!(outcome.is_finished());
+    /// ```
+    #[must_use]
+    pub fn finished(value: Value) -> Self {
+        let text = match &value {
+            Value::String(s) => Some(s.clone()),
+            Value::Object(map) => map.get("text").and_then(Value::as_str).map(str::to_string),
+            _ => None,
+        };
+        let json = match &value {
+            Value::Object(_) | Value::Array(_) => value.clone(),
+            _ => Value::Null,
+        };
+        Self {
+            stop: StopReason::Finished,
+            text,
+            json,
+            raw: value,
+            usage: None,
+        }
+    }
+
+    /// Whether the agent reached a final answer.
+    ///
+    /// Anything else means the payload is partial or absent — see
+    /// [`StopReason`].
+    #[must_use]
+    pub fn is_finished(&self) -> bool {
+        matches!(self.stop, StopReason::Finished)
+    }
+}
+
+/// Runs a host-registered, multi-turn **agent** — the harness seam.
+///
+/// Where [`LlmProvider::complete`](crate::caps::LlmProvider::complete) is a
+/// single chat call, an `AgentRunner` runs a *named agent kind* the host has
+/// defined — a coding agent, a researcher, a crypto agent — each bringing its
+/// own curated tool access, model, sandbox, and iteration policy. An `agent`
+/// node selects one via a trusted `agent_ref` in its config; when the host wires
+/// this capability, the node runs that agent to completion instead of issuing a
+/// bare completion.
+///
+/// The engine stays host-agnostic: `agent_ref` is an opaque id the host resolves
+/// against its own agent registry (or that the graph's own
+/// [`agents`](crate::model::WorkflowGraph::agents) registry answers first). This
+/// capability is **optional** — hosts without an agent registry leave
+/// [`Capabilities::agent`](crate::caps::Capabilities::agent) `None`, and `agent`
+/// nodes fall back to [`LlmProvider`](crate::caps::LlmProvider).
+///
+/// # Implementing it
+///
+/// Only [`run_agent`](Self::run_agent) is required, and it is unchanged from the
+/// previous release. Every other method has a default that degrades to the
+/// behavior a host had before richer agents existed, so an existing
+/// implementation keeps compiling and keeps behaving identically. Override them
+/// in roughly this order of value:
+///
+/// 1. [`run`](Self::run) — take the typed request, and report a real
+///    [`StopReason`]. The default reports [`Finished`](StopReason::Finished) for
+///    every run, which is exactly the conflation this trait exists to remove, so
+///    a harness with a real loop should not leave it defaulted.
+/// 2. [`resolve_agent`](Self::resolve_agent) — expose the host's own agent
+///    catalogue to graphs.
+/// 3. [`resolve_context`](Self::resolve_context) — expand `host` context
+///    sources.
+/// 4. [`resolve_tools`](Self::resolve_tools) — describe tools and expand
+///    namespace patterns.
+#[async_trait]
+pub trait AgentRunner: Send + Sync {
+    /// Runs the host-registered agent identified by `agent_ref` to completion.
+    ///
+    /// `request` is the (expression-resolved) node config — prompt/input plus
+    /// any per-node overrides the host chooses to honor. `conn` is the same
+    /// opaque, host-managed connection reference the other capabilities take.
+    /// The returned JSON is treated exactly like a completion response by the
+    /// `agent` node (enveloped into `{ json, text, raw }`), so downstream
+    /// binding is identical to a plain agent turn.
+    ///
+    /// # Errors
+    /// Returns an [`EngineError::Capability`](crate::error::EngineError::Capability)
+    /// when `agent_ref` is unknown or the agent run fails.
+    async fn run_agent(&self, agent_ref: &str, request: Value, conn: Option<&str>)
+    -> Result<Value>;
+
+    /// Runs a fully-assembled [`AgentRunRequest`] until the loop finishes, hits
+    /// a limit, or pauses.
+    ///
+    /// A limit stop and a pause are **not errors** — they are reported through
+    /// [`AgentRunOutcome::stop`], so a harness's own failures (an unreachable
+    /// model, a rejected credential) stay distinguishable from a loop that ran
+    /// and deliberately stopped.
+    ///
+    /// The default implementation forwards
+    /// [`request.config`](AgentRunRequest::config) — the node's resolved config,
+    /// verbatim — to [`run_agent`](Self::run_agent) and reports the result as
+    /// [`Finished`](StopReason::Finished). That is byte-for-byte the call a host
+    /// received before this method existed, so leaving it defaulted preserves
+    /// existing behavior exactly. It does mean the host cannot signal a partial
+    /// or paused run, which is why a harness with a real loop should override
+    /// it.
+    ///
+    /// # Errors
+    /// Returns an [`EngineError::Capability`](crate::error::EngineError::Capability)
+    /// when the harness cannot run the request at all.
+    async fn run(&self, request: AgentRunRequest) -> Result<AgentRunOutcome> {
+        let value = self
+            .run_agent(
+                &request.agent.id,
+                request.config.clone(),
+                request.connection_ref.as_deref(),
+            )
+            .await?;
+        Ok(AgentRunOutcome::finished(value))
+    }
+
+    /// Resolves `agent_ref` against the host's own agent catalogue.
+    ///
+    /// The **fallback** half of agent-kind resolution: a graph's own
+    /// [`agents`](crate::model::WorkflowGraph::agents) registry is consulted
+    /// first and wins on a collision, so a workflow stays portable between
+    /// hosts. This method is how a harness adds curated kinds no graph should
+    /// have to inline.
+    ///
+    /// Read-only on purpose. A directory the engine could write to would let a
+    /// running workflow mint itself an agent with tools it was never granted.
+    ///
+    /// **`Ok(None)` for an unknown ref is a normal outcome, not a soft error** —
+    /// the node then passes the ref through to [`run`](Self::run) as a bare
+    /// `AgentDefinition { id: agent_ref, .. }`, which is what a harness that
+    /// resolves refs internally wants. The default returns `Ok(None)` for
+    /// everything, which is exactly that pass-through behavior.
+    ///
+    /// # Errors
+    /// Returns an [`EngineError::Capability`](crate::error::EngineError::Capability)
+    /// only on a genuine failure to answer — a broken store, a lost connection.
+    async fn resolve_agent(&self, agent_ref: &str) -> Result<Option<AgentDefinition>> {
+        let _ = agent_ref;
+        Ok(None)
+    }
+
+    /// Every agent kind the harness offers, for an editor's picker and for
+    /// authoring surfaces. Order should be stable across calls.
+    ///
+    /// Not on the run path — nothing in [`crate::engine`] calls this.
+    ///
+    /// # Errors
+    /// Returns an [`EngineError::Capability`](crate::error::EngineError::Capability)
+    /// when the catalogue cannot be listed.
+    async fn list_agents(&self) -> Result<Vec<AgentDefinition>> {
+        Ok(Vec::new())
+    }
+
+    /// Resolves an opaque
+    /// [`ContextSourceKind::Host`](crate::model::ContextSourceKind::Host)
+    /// source into a [`ContextBlock`] — identity/soul text, a description of the
+    /// integrations this user has connected, a RAG index, learned context.
+    ///
+    /// This is deliberately *not* a prompt composer. The harness owns the loop
+    /// and therefore owns the system prompt; a second prompt-composition seam
+    /// here would duplicate or fight the harness's own. All this does is turn an
+    /// author-declared source name into a block that rides along in the request.
+    ///
+    /// It also does not overlap [`MemoryProvider`](crate::caps::MemoryProvider):
+    /// `memory` and `flavour` context sources route to that existing capability
+    /// unchanged, so the memory `scope` contract keeps exactly one home.
+    ///
+    /// **`Ok(None)` for an unrecognized `source` is a normal outcome**; the node
+    /// then applies the block's `optional` policy, failing unless the author
+    /// marked the source optional. Returning `Ok(Some(_))` with an empty block
+    /// is different and also normal: the source resolved and has nothing to
+    /// contribute this run.
+    ///
+    /// # Errors
+    /// Returns an [`EngineError::Capability`](crate::error::EngineError::Capability)
+    /// only on a genuine failure to answer.
+    async fn resolve_context(
+        &self,
+        source: &str,
+        params: &Value,
+        identity: &AgentRunIdentity,
+    ) -> Result<Option<ContextBlock>> {
+        let _ = (source, params, identity);
+        Ok(None)
+    }
+
+    /// Expands an agent's [`ToolGrant`]s into concrete [`ToolDescriptor`]s.
+    ///
+    /// The discovery half [`ToolInvoker`](crate::caps::ToolInvoker) lacks:
+    /// `invoke(slug, args, conn)` can execute a tool but cannot say which tools
+    /// exist, what they take, or what `"github.*"` expands to.
+    ///
+    /// `conn` is the node's connection reference, so a harness whose visible
+    /// tool set depends on the account can narrow accordingly. A grant matching
+    /// nothing contributes nothing — that is not an error, for the same
+    /// build-variance reason an unknown agent id is not.
+    ///
+    /// The default returns one undescribed [`ToolDescriptor`] per grant, with
+    /// patterns forwarded verbatim — appropriate for a harness that already
+    /// knows its own tools and only needs to be told which ones are permitted.
+    ///
+    /// # Errors
+    /// Returns an [`EngineError::Capability`](crate::error::EngineError::Capability)
+    /// when the catalogue cannot be consulted.
+    async fn resolve_tools(
+        &self,
+        grants: &[ToolGrant],
+        conn: Option<&str>,
+    ) -> Result<Vec<ToolDescriptor>> {
+        Ok(grants
+            .iter()
+            .map(|grant| ToolDescriptor::from_grant(grant, conn))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A host written against the previous release: one method, JSON in and out.
+    struct LegacyRunner;
+
+    #[async_trait]
+    impl AgentRunner for LegacyRunner {
+        async fn run_agent(
+            &self,
+            agent_ref: &str,
+            request: Value,
+            conn: Option<&str>,
+        ) -> Result<Value> {
+            Ok(json!({ "agent": agent_ref, "request": request, "connection": conn }))
+        }
+    }
+
+    fn request(config: Value) -> AgentRunRequest {
+        AgentRunRequest {
+            agent: AgentDefinition::new("researcher"),
+            model: AgentModelSelection::default(),
+            input: AgentInput::default(),
+            context: Vec::new(),
+            tools: Vec::new(),
+            connection_ref: Some("conn_1".to_string()),
+            identity: AgentRunIdentity::default(),
+            metadata: Map::new(),
+            output_schema: None,
+            config,
+        }
+    }
+
+    #[tokio::test]
+    async fn the_default_run_forwards_the_config_verbatim_to_run_agent() {
+        // The non-breaking guarantee: a host that implements only `run_agent`
+        // receives exactly the (agent_ref, config, conn) triple it always did.
+        let config = json!({ "prompt": "hi", "agent_ref": "researcher" });
+        let outcome = LegacyRunner.run(request(config.clone())).await.unwrap();
+
+        assert_eq!(
+            outcome.raw,
+            json!({ "agent": "researcher", "request": config, "connection": "conn_1" })
+        );
+        assert_eq!(outcome.stop, StopReason::Finished);
+    }
+
+    #[tokio::test]
+    async fn the_default_resolvers_report_absence_not_failure() {
+        assert!(LegacyRunner.resolve_agent("anything").await.unwrap().is_none());
+        assert!(LegacyRunner.list_agents().await.unwrap().is_empty());
+        assert!(
+            LegacyRunner
+                .resolve_context("soul", &Value::Null, &AgentRunIdentity::default())
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn the_default_tool_resolver_passes_grants_through_undescribed() {
+        let grants = vec![
+            ToolGrant::new("github.*"),
+            ToolGrant {
+                slug: "slack.post".to_string(),
+                connection_ref: Some("acct_slack".to_string()),
+            },
+        ];
+        let tools = LegacyRunner
+            .resolve_tools(&grants, Some("node_conn"))
+            .await
+            .unwrap();
+
+        assert_eq!(tools[0].slug, "github.*", "patterns are forwarded verbatim");
+        assert_eq!(
+            tools[0].connection_ref.as_deref(),
+            Some("node_conn"),
+            "a grant without its own connection falls back to the node's"
+        );
+        assert_eq!(
+            tools[1].connection_ref.as_deref(),
+            Some("acct_slack"),
+            "a grant's own connection wins"
+        );
+        assert!(tools[0].input_schema.is_none());
+    }
+
+    #[test]
+    fn finished_derives_text_and_json_like_the_envelope() {
+        let from_object = AgentRunOutcome::finished(json!({ "text": "done", "n": 1 }));
+        assert_eq!(from_object.text.as_deref(), Some("done"));
+        assert_eq!(from_object.json, json!({ "text": "done", "n": 1 }));
+
+        let from_string = AgentRunOutcome::finished(json!("just prose"));
+        assert_eq!(from_string.text.as_deref(), Some("just prose"));
+        assert_eq!(from_string.json, Value::Null, "a scalar carries no structure");
+    }
+
+    #[test]
+    fn stop_reasons_have_stable_wire_names() {
+        assert_eq!(StopReason::Finished.as_str(), "finished");
+        assert_eq!(
+            StopReason::LimitStop { limit: "max_steps".into() }.as_str(),
+            "limit_stop"
+        );
+        assert_eq!(
+            serde_json::to_value(StopReason::LimitStop { limit: "max_steps".into() }).unwrap(),
+            json!({ "stop": "limit_stop", "limit": "max_steps" })
+        );
+    }
+}

--- a/src/caps/agent.rs
+++ b/src/caps/agent.rs
@@ -643,6 +643,7 @@ mod tests {
             context: Vec::new(),
             tools: Vec::new(),
             connection_ref: Some("conn_1".to_string()),
+            working_dir: None,
             identity: AgentRunIdentity::default(),
             metadata: Map::new(),
             output_schema: None,

--- a/src/caps/mock.rs
+++ b/src/caps/mock.rs
@@ -166,22 +166,24 @@ impl AgentRunner for MockAgentHarness {
         // tell an expanded grant from a passed-through one.
         Ok(grants
             .iter()
-            .flat_map(|grant| match grant.slug.strip_suffix(".*") {
-                Some(ns) => vec![format!("{ns}.alpha"), format!("{ns}.beta")],
-                None => vec![grant.slug.clone()],
-            }
-            .into_iter()
-            .map(|slug| crate::caps::ToolDescriptor {
-                description: Some(format!("mock tool {slug}")),
-                input_schema: Some(json!({ "type": "object" })),
-                connection_ref: grant
-                    .connection_ref
-                    .clone()
-                    .or_else(|| conn.map(str::to_string)),
-                name: None,
-                slug,
+            .flat_map(|grant| {
+                match grant.slug.strip_suffix(".*") {
+                    Some(ns) => vec![format!("{ns}.alpha"), format!("{ns}.beta")],
+                    None => vec![grant.slug.clone()],
+                }
+                .into_iter()
+                .map(|slug| crate::caps::ToolDescriptor {
+                    description: Some(format!("mock tool {slug}")),
+                    input_schema: Some(json!({ "type": "object" })),
+                    connection_ref: grant
+                        .connection_ref
+                        .clone()
+                        .or_else(|| conn.map(str::to_string)),
+                    name: None,
+                    slug,
+                })
+                .collect::<Vec<_>>()
             })
-            .collect::<Vec<_>>())
             .collect())
     }
 }
@@ -194,7 +196,12 @@ pub struct MockLimitedAgentRunner;
 
 #[async_trait]
 impl AgentRunner for MockLimitedAgentRunner {
-    async fn run_agent(&self, _agent_ref: &str, _request: Value, _conn: Option<&str>) -> Result<Value> {
+    async fn run_agent(
+        &self,
+        _agent_ref: &str,
+        _request: Value,
+        _conn: Option<&str>,
+    ) -> Result<Value> {
         Ok(Value::Null)
     }
 
@@ -223,7 +230,12 @@ pub struct MockPausingAgentRunner;
 
 #[async_trait]
 impl AgentRunner for MockPausingAgentRunner {
-    async fn run_agent(&self, _agent_ref: &str, _request: Value, _conn: Option<&str>) -> Result<Value> {
+    async fn run_agent(
+        &self,
+        _agent_ref: &str,
+        _request: Value,
+        _conn: Option<&str>,
+    ) -> Result<Value> {
         Ok(Value::Null)
     }
 

--- a/src/caps/mock.rs
+++ b/src/caps/mock.rs
@@ -45,6 +45,206 @@ impl AgentRunner for MockAgentRunner {
     }
 }
 
+/// An [`AgentRunner`] that implements the **typed** seam: it echoes the
+/// assembled [`AgentRunRequest`](crate::caps::AgentRunRequest) rather than the
+/// raw config, and can answer registry and context lookups.
+///
+/// Where [`MockAgentRunner`] stands in for a host written against the previous
+/// release (only `run_agent`, so the default `run` shim applies), this one
+/// stands in for a harness that has opted in — which is what a test asserting
+/// merge semantics, context resolution, or tool narrowing needs to see.
+///
+/// The echo is deliberately *shaped* rather than a blob, so a downstream
+/// `condition` or `transform` in a dry run has stable fields to bind to.
+#[derive(Debug, Default, Clone)]
+pub struct MockAgentHarness {
+    /// Agent kinds this mock registry knows, consulted by
+    /// [`resolve_agent`](AgentRunner::resolve_agent) when the graph does not
+    /// declare the ref itself.
+    pub agents: Vec<crate::model::AgentDefinition>,
+}
+
+impl MockAgentHarness {
+    /// A harness with an empty registry — every `resolve_agent` misses, so refs
+    /// pass through as bare ids.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers an agent kind, mirroring [`MockWorkflowResolver::with`].
+    #[must_use]
+    pub fn with(mut self, agent: crate::model::AgentDefinition) -> Self {
+        self.agents.push(agent);
+        self
+    }
+}
+
+#[async_trait]
+impl AgentRunner for MockAgentHarness {
+    async fn run_agent(
+        &self,
+        agent_ref: &str,
+        request: Value,
+        conn: Option<&str>,
+    ) -> Result<Value> {
+        Ok(json!({ "agent": agent_ref, "request": request, "connection": conn }))
+    }
+
+    async fn run(
+        &self,
+        request: crate::caps::AgentRunRequest,
+    ) -> Result<crate::caps::AgentRunOutcome> {
+        let echo = json!({
+            "agent": request.agent.id,
+            "instructions": request.agent.instructions,
+            "model": request.model.model,
+            "provider": request.model.provider,
+            "working_dir": request.working_dir,
+            "limits": request.agent.limits,
+            "metadata": request.metadata,
+            "prompt": request.input.text,
+            "data": request.input.data,
+            "context": request
+                .context
+                .iter()
+                .map(|b| json!({ "label": b.label, "kind": b.source_kind, "text": b.text, "data": b.data }))
+                .collect::<Vec<_>>(),
+            "tools": request.tools.iter().map(|t| t.slug.clone()).collect::<Vec<_>>(),
+            "connection": request.connection_ref,
+            "identity": request.identity,
+        });
+        Ok(crate::caps::AgentRunOutcome {
+            stop: crate::caps::StopReason::Finished,
+            text: Some(format!("ran {}", request.agent.id)),
+            json: echo.clone(),
+            raw: echo,
+            usage: Some(crate::caps::AgentUsage {
+                steps: Some(1),
+                ..Default::default()
+            }),
+        })
+    }
+
+    async fn resolve_agent(
+        &self,
+        agent_ref: &str,
+    ) -> Result<Option<crate::model::AgentDefinition>> {
+        Ok(self.agents.iter().find(|a| a.id == agent_ref).cloned())
+    }
+
+    async fn list_agents(&self) -> Result<Vec<crate::model::AgentDefinition>> {
+        Ok(self.agents.clone())
+    }
+
+    async fn resolve_context(
+        &self,
+        source: &str,
+        params: &Value,
+        _identity: &crate::caps::AgentRunIdentity,
+    ) -> Result<Option<crate::caps::ContextBlock>> {
+        // `"unknown"` is the one source this mock refuses, so a test can cover
+        // the `Ok(None)` path (and the `optional` policy that rides on it)
+        // without needing a second mock.
+        if source == "unknown" {
+            return Ok(None);
+        }
+        Ok(Some(crate::caps::ContextBlock {
+            label: source.to_string(),
+            source_kind: "host".to_string(),
+            text: Some(format!("mock context for {source:?}")),
+            data: params.clone(),
+        }))
+    }
+
+    async fn resolve_tools(
+        &self,
+        grants: &[crate::model::ToolGrant],
+        conn: Option<&str>,
+    ) -> Result<Vec<crate::caps::ToolDescriptor>> {
+        // Expands a trailing-`.*` pattern into two concrete slugs, so a test can
+        // tell an expanded grant from a passed-through one.
+        Ok(grants
+            .iter()
+            .flat_map(|grant| match grant.slug.strip_suffix(".*") {
+                Some(ns) => vec![format!("{ns}.alpha"), format!("{ns}.beta")],
+                None => vec![grant.slug.clone()],
+            }
+            .into_iter()
+            .map(|slug| crate::caps::ToolDescriptor {
+                description: Some(format!("mock tool {slug}")),
+                input_schema: Some(json!({ "type": "object" })),
+                connection_ref: grant
+                    .connection_ref
+                    .clone()
+                    .or_else(|| conn.map(str::to_string)),
+                name: None,
+                slug,
+            })
+            .collect::<Vec<_>>())
+            .collect())
+    }
+}
+
+/// An [`AgentRunner`] whose loop always stops on a limit, keeping partial
+/// output — for tests covering the `limit_stop` path (`meta.stop`, and the
+/// output parser being skipped on a knowingly partial payload).
+#[derive(Debug, Default, Clone)]
+pub struct MockLimitedAgentRunner;
+
+#[async_trait]
+impl AgentRunner for MockLimitedAgentRunner {
+    async fn run_agent(&self, _agent_ref: &str, _request: Value, _conn: Option<&str>) -> Result<Value> {
+        Ok(Value::Null)
+    }
+
+    async fn run(
+        &self,
+        request: crate::caps::AgentRunRequest,
+    ) -> Result<crate::caps::AgentRunOutcome> {
+        let partial = json!({ "partial": true, "agent": request.agent.id });
+        Ok(crate::caps::AgentRunOutcome {
+            stop: crate::caps::StopReason::LimitStop {
+                limit: "max_steps".to_string(),
+            },
+            text: Some("got as far as I could".to_string()),
+            json: partial.clone(),
+            raw: partial,
+            usage: None,
+        })
+    }
+}
+
+/// An [`AgentRunner`] whose loop always pauses for a human — for tests covering
+/// the (currently unsupported) resume path failing loudly rather than emitting a
+/// half-run agent's output as an answer.
+#[derive(Debug, Default, Clone)]
+pub struct MockPausingAgentRunner;
+
+#[async_trait]
+impl AgentRunner for MockPausingAgentRunner {
+    async fn run_agent(&self, _agent_ref: &str, _request: Value, _conn: Option<&str>) -> Result<Value> {
+        Ok(Value::Null)
+    }
+
+    async fn run(
+        &self,
+        _request: crate::caps::AgentRunRequest,
+    ) -> Result<crate::caps::AgentRunOutcome> {
+        Ok(crate::caps::AgentRunOutcome {
+            stop: crate::caps::StopReason::Paused {
+                token: Some("mock_pause_1".to_string()),
+                reason: "tool_approval".to_string(),
+                payload: json!({ "tool": "github.add_labels" }),
+            },
+            text: None,
+            json: Value::Null,
+            raw: Value::Null,
+            usage: None,
+        })
+    }
+}
+
 /// A [`ToolInvoker`] that echoes the slug and args it was called with.
 #[derive(Debug, Default, Clone)]
 pub struct MockTools;

--- a/src/caps/mod.rs
+++ b/src/caps/mod.rs
@@ -29,37 +29,6 @@ pub trait LlmProvider: Send + Sync {
     async fn complete(&self, request: Value, conn: Option<&str>) -> Result<Value>;
 }
 
-/// Runs a host-registered, multi-turn **agent** identified by a stable id.
-///
-/// Where [`LlmProvider::complete`] is a single chat call, an `AgentRunner` runs
-/// a *named agent kind* the host has defined — a coding agent, a researcher, a
-/// crypto agent — each bringing its own curated tool access, model, sandbox, and
-/// iteration policy. An `agent` node selects one via a trusted `agent_ref` in its
-/// config; when the host wires this capability, the node runs that agent to
-/// completion instead of issuing a bare completion.
-///
-/// The engine stays host-agnostic: `agent_ref` is an opaque id the host resolves
-/// against its own agent registry. This capability is **optional** — hosts
-/// without an agent registry leave [`Capabilities::agent`] `None`, and `agent`
-/// nodes fall back to [`LlmProvider`].
-#[async_trait]
-pub trait AgentRunner: Send + Sync {
-    /// Runs the host-registered agent identified by `agent_ref` to completion.
-    ///
-    /// `request` is the (expression-resolved) node config — prompt/input plus any
-    /// per-node overrides the host chooses to honor (e.g. a narrowing tool
-    /// allow-list). `conn` is the same opaque, host-managed connection reference
-    /// the other capabilities take. The returned JSON is treated exactly like a
-    /// completion response by the `agent` node (enveloped into `{ json, text,
-    /// raw }`), so downstream binding is identical to a plain agent turn.
-    ///
-    /// # Errors
-    /// Returns an [`EngineError::Capability`](crate::error::EngineError::Capability)
-    /// when `agent_ref` is unknown or the agent run fails.
-    async fn run_agent(&self, agent_ref: &str, request: Value, conn: Option<&str>)
-    -> Result<Value>;
-}
-
 /// Host-injected memory access for `memory` nodes.
 ///
 /// A `memory` node is a **delivery surface** onto whatever durable memory store

--- a/src/caps/mod.rs
+++ b/src/caps/mod.rs
@@ -17,6 +17,10 @@ use serde_json::Value;
 
 use crate::error::Result;
 
+pub use self::agent::{
+    AgentInput, AgentModelSelection, AgentRunIdentity, AgentRunOutcome, AgentRunRequest,
+    AgentRunner, AgentUsage, ContextBlock, StopReason, ToolDescriptor,
+};
 pub use self::shell::{ShellInterpreter, ShellOutcome, ShellRequest, ShellRunner, ShellScript};
 
 /// A chat / LLM provider used by `agent` and `output_parser` nodes.

--- a/src/caps/mod.rs
+++ b/src/caps/mod.rs
@@ -5,6 +5,7 @@
 //! adapter seam (`src/openhuman/tinyflows/`) wires these to its inference stack,
 //! curated Composio tools, `HttpRequestTool`, and sandboxed code runtimes.
 
+pub mod agent;
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
 pub mod shell;

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -344,6 +344,31 @@ pub fn contract_for(kind: &str) -> Option<NodeKindContract> {
                  output_parser.schema — an untyped field can carry the truthy string \"false\" and \
                  route to the wrong port."
                     .to_string(),
+                "Reusable agent types live in the graph's TOP-LEVEL `agents` array (a sibling of \
+                 `nodes`/`edges`/`inputs`), each {id, name?, description?, instructions?, model?, \
+                 provider?, working_dir?, tools?, context?, limits?, metadata?}. A node's \
+                 agent_ref resolves there first, then against the host's registry; a ref neither \
+                 knows is passed through to the harness as an id, which is not an error."
+                    .to_string(),
+                "Merge order is definition-then-node, narrowing only: instructions append, \
+                 context appends, tools intersect, limits take the lower bound, metadata merges \
+                 per key, and model/provider/working_dir are overridden by the node."
+                    .to_string(),
+                "agent_ref, tool slug, tool connection_ref, a memory context scope, and a host \
+                 context source must all be LITERALS, never =expressions — otherwise run data \
+                 (which may include model output) could choose the credential a call acts as, the \
+                 tool it reaches, or the agent type it runs as."
+                    .to_string(),
+                "The output item carries a `meta` key alongside json/text/raw: `=item.meta.stop` \
+                 is \"finished\" or \"limit_stop\", so a downstream condition can branch on \
+                 whether the agent actually reached an answer instead of assuming it did. A \
+                 limit_stop output is PARTIAL and skips output_parser."
+                    .to_string(),
+                "A `memory` or `flavour` context block needs the host's MemoryProvider, and a \
+                 `host` block needs the harness's context resolver; without them the node fails \
+                 unless the block sets optional:true. Silently dropping context would leave the \
+                 agent answering confidently from nothing."
+                    .to_string(),
             ],
         },
         "tool_call" => NodeKindContract {

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -246,17 +246,76 @@ pub fn contract_for(kind: &str) -> Option<NodeKindContract> {
         "agent" => NodeKindContract {
             kind: "agent".to_string(),
             summary: "An LLM step, run via the host's LlmProvider capability.".to_string(),
-            description: "Runs config.prompt through the injected LlmProvider. config.agent_ref \
-                may select a host-registered agent persona; config.output_parser.schema requests a \
-                structured, field-addressable output item. The exact data-input convention (how \
-                the upstream item reaches the prompt) is defined by the host's LlmProvider."
+            description: "Runs config.prompt through the injected LlmProvider, or — when \
+                config.agent_ref names an agent type and the host wired an AgentRunner — through \
+                that agent's own loop. An agent type is defined either in the graph's top-level \
+                `agents` registry or by the host; the node may then NARROW it (fewer tools, lower \
+                limits, extra instructions) but never widen it. config.output_parser.schema \
+                requests a structured, field-addressable output item. tinyflows runs no agent \
+                loop itself: it assembles the request and the harness executes it."
                 .to_string(),
             config_fields: vec![
                 ConfigField::required("prompt", "string", "The instruction sent to the model."),
                 ConfigField::optional(
                     "agent_ref",
                     "string",
-                    "A host-registered agent-kind id to run this step as (persona/model).",
+                    "The agent type to run this step as. Resolved against the graph's `agents` \
+                     registry first, then the host's. Must be a LITERAL — an =expression is \
+                     rejected, since run data must not choose a differently-privileged agent.",
+                ),
+                ConfigField::optional(
+                    "instructions",
+                    "string",
+                    "Extra standing instructions for this step. APPENDED to the agent \
+                     definition's, never replacing them.",
+                ),
+                ConfigField::optional(
+                    "model",
+                    "string",
+                    "Model id, opaque to the engine. Overrides the agent definition's.",
+                ),
+                ConfigField::optional(
+                    "provider",
+                    "string",
+                    "Provider id, opaque to the engine (e.g. a gateway or routing key). Carried \
+                     separately from `model` so a host routing one model through several \
+                     providers need not parse a composite string.",
+                ),
+                ConfigField::optional(
+                    "working_dir",
+                    "string",
+                    "Working directory the agent runs in, when it runs somewhere with a \
+                     filesystem. Opaque and UNTRUSTED: the engine never touches the filesystem, \
+                     so the host must validate it against its own permitted roots.",
+                ),
+                ConfigField::optional(
+                    "context",
+                    "array",
+                    "Dynamic context blocks, each {kind, label?, optional?}: kind=text {text} \
+                     (literal or =expression); items (the node's input items); memory \
+                     {scope,query,limit?} and flavour {slug} (via the host's MemoryProvider); \
+                     host {source,params?} (expanded by the harness). A block that cannot be \
+                     resolved FAILS the node unless it sets optional:true.",
+                ),
+                ConfigField::optional(
+                    "tools",
+                    "array",
+                    "Tool grants, each {slug, connection_ref?}. slug is an exact id or a \
+                     trailing-.* namespace pattern; both it and connection_ref must be literals. \
+                     When the agent definition grants tools, this list may only NARROW them.",
+                ),
+                ConfigField::optional(
+                    "limits",
+                    "object",
+                    "Advisory ceilings for the harness's loop: {max_steps?, max_tool_calls?, \
+                     max_seconds?}. May only LOWER the agent definition's. Advisory because the \
+                     loop runs host-side — node_timeout_secs is the bound the engine enforces.",
+                ),
+                ConfigField::optional(
+                    "metadata",
+                    "object",
+                    "Free-form passthrough to the harness (tier hints, sandbox policy, …), \
+                     merged key-wise over the agent definition's. Never interpreted by the engine.",
                 ),
                 ConfigField::optional(
                     "output_parser",

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -308,8 +308,11 @@ pub fn contract_for(kind: &str) -> Option<NodeKindContract> {
                     "limits",
                     "object",
                     "Advisory ceilings for the harness's loop: {max_steps?, max_tool_calls?, \
-                     max_seconds?}. May only LOWER the agent definition's. Advisory because the \
-                     loop runs host-side — node_timeout_secs is the bound the engine enforces.",
+                     agent_timeout_secs?, tool_timeout_secs?}. agent_timeout_secs bounds the whole \
+                     run; tool_timeout_secs bounds each individual tool call, so one wedged tool \
+                     cannot eat the whole budget. May only LOWER the agent definition's. Advisory \
+                     because the loop runs host-side — node_timeout_secs is what the engine \
+                     itself enforces.",
                 ),
                 ConfigField::optional(
                     "metadata",

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -976,6 +976,14 @@ fn build_graph(
     // budgets. The per-attempt bound is applied inside the handler's retry loop
     // instead (raced against each attempt), so it is the sole timeout in effect.
 
+    // The graph's own agent registry, shared by every node handler. An `agent`
+    // node resolves its `agent_ref` here first (see `crate::nodes::integration`),
+    // falling back to the harness's registry. Held behind an `Arc` and cloned per
+    // handler rather than seeded into run state, which is checkpointed on every
+    // super-step: the registry is static for the run, so serializing it into each
+    // checkpoint to read it back in one node would be pure waste.
+    let agents: Arc<Vec<crate::model::AgentDefinition>> = Arc::new(graph.agents.clone());
+
     for node in &graph.nodes {
         let node = node.clone();
         // Incoming edges as `(predecessor id, edge from_port)` pairs, so
@@ -1001,6 +1009,7 @@ fn build_graph(
             .map(|e| (e.from_node.clone(), e.from_port.clone()))
             .collect();
         let caps = capabilities.clone();
+        let agents = agents.clone();
         let observer = observer.clone();
         let steps = steps.clone();
         let terminal_error = terminal_error.clone();
@@ -1021,6 +1030,7 @@ fn build_graph(
             let incoming = incoming.clone();
             let back_incoming = back_incoming.clone();
             let caps = caps.clone();
+            let agents = agents.clone();
             let observer = observer.clone();
             let steps = steps.clone();
             let terminal_error = terminal_error.clone();
@@ -1276,6 +1286,7 @@ fn build_graph(
                         run: &run_meta,
                         nodes: &nodes_state,
                         caps: &caps,
+                        agents: &agents,
                         observer: observer.as_ref(),
                         // Handed to the executor so a nested engine call (today the
                         // `sub_workflow` node) can thread this run's cancellation
@@ -1401,6 +1412,7 @@ fn build_graph(
                                 run: &run_meta,
                                 nodes: &nodes_state,
                                 caps: &caps,
+                                agents: &agents,
                                 observer: observer.as_ref(),
                                 token: token.clone(),
                             };

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1286,6 +1286,7 @@ fn build_graph(
                         run: &run_meta,
                         nodes: &nodes_state,
                         caps: &caps,
+                        agents: &[],
                         agents: &agents,
                         observer: observer.as_ref(),
                         // Handed to the executor so a nested engine call (today the
@@ -1412,6 +1413,7 @@ fn build_graph(
                                 run: &run_meta,
                                 nodes: &nodes_state,
                                 caps: &caps,
+                                agents: &[],
                                 agents: &agents,
                                 observer: observer.as_ref(),
                                 token: token.clone(),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1286,7 +1286,6 @@ fn build_graph(
                         run: &run_meta,
                         nodes: &nodes_state,
                         caps: &caps,
-                        agents: &[],
                         agents: &agents,
                         observer: observer.as_ref(),
                         // Handed to the executor so a nested engine call (today the
@@ -1413,7 +1412,6 @@ fn build_graph(
                                 run: &run_meta,
                                 nodes: &nodes_state,
                                 caps: &caps,
-                                agents: &[],
                                 agents: &agents,
                                 observer: observer.as_ref(),
                                 token: token.clone(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,21 @@ pub enum ValidationError {
     #[error("illegal cycle detected involving node: {0}")]
     IllegalCycle(String),
 
+    /// Two entries in the graph's agent registry share an id, so an
+    /// `agent_ref` naming it would resolve ambiguously.
+    #[error("duplicate agent definition id: {0}")]
+    DuplicateAgentId(String),
+
+    /// An entry in the graph's agent registry is malformed.
+    #[error("invalid agent definition {agent}: {reason}")]
+    InvalidAgentDefinition {
+        /// The offending definition's id, empty when the id itself is the
+        /// problem.
+        agent: String,
+        /// Why the definition is invalid.
+        reason: String,
+    },
+
     /// A node's configuration is invalid for its kind.
     #[error("invalid config for node {node}: {reason}")]
     InvalidNodeConfig {

--- a/src/error.rs
+++ b/src/error.rs
@@ -158,6 +158,8 @@ impl ValidationError {
             Self::MultipleTriggers(_) => "multiple_triggers",
             Self::UnknownNode(_) => "unknown_node",
             Self::DuplicateNodeId(_) => "duplicate_node_id",
+            Self::DuplicateAgentId(_) => "duplicate_agent_id",
+            Self::InvalidAgentDefinition { .. } => "invalid_agent_definition",
             Self::IllegalCycle(_) => "illegal_cycle",
             Self::InvalidNodeConfig { .. } => "invalid_node_config",
             Self::MissingErrorRoute(_) => "missing_error_route",
@@ -178,6 +180,8 @@ impl ValidationError {
     /// `SchemaVersionTooNew`), for `MultipleTriggers` (which carries many ids in
     /// its payload rather than a single anchor), and for the declared-input
     /// errors (anchored to an input, not a node — see [`Self::input_name`]).
+    /// Also `None` for the agent-registry errors, which are anchored to an agent
+    /// definition rather than to any one node that references it.
     /// Lets a host attach the error to the right node in a structured
     /// validation report.
     pub fn node_id(&self) -> Option<&str> {
@@ -196,7 +200,9 @@ impl ValidationError {
             | Self::DuplicateInputName(_)
             | Self::InvalidInputName(_)
             | Self::InputDefaultTypeMismatch { .. }
-            | Self::RequiredInputWithDefault(_) => None,
+            | Self::RequiredInputWithDefault(_)
+            | Self::DuplicateAgentId(_)
+            | Self::InvalidAgentDefinition { .. } => None,
         }
     }
 

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -1,0 +1,520 @@
+//! Declarative agent types: what an `agent` node runs, and how it is configured.
+//!
+//! An [`AgentDefinition`] is a **reusable agent type** — instructions, model,
+//! provider, granted tools, standing context, and advisory limits. Definitions
+//! come from two places, and an `agent` node's `agent_ref` selects one:
+//!
+//! | source | declared in | resolved by | portable |
+//! |---|---|---|---|
+//! | in-graph registry | [`WorkflowGraph::agents`](crate::model::WorkflowGraph::agents) | the engine | yes — travels with the workflow |
+//! | host registry | the embedding harness | [`AgentRunner::resolve_agent`](crate::caps::AgentRunner::resolve_agent) | no — host-specific |
+//!
+//! The in-graph registry wins on a collision, so a workflow that carries its own
+//! definition behaves the same on every host. An `agent_ref` that neither
+//! resolves is **not** an error: it is passed through to the harness as a
+//! minimal `AgentDefinition { id: agent_ref, .. }`, preserving the pre-registry
+//! behavior where `agent_ref` was an opaque string the host interpreted.
+//!
+//! ## What this module is not
+//!
+//! tinyflows implements **no agentic loop**. These types describe an agent
+//! *declaratively* so the engine can assemble a
+//! [`AgentRunRequest`](crate::caps::AgentRunRequest); the model↔tool loop, the
+//! transcript, and the prompt assembly all belong to the harness. Everything
+//! here is `serde` + `std` only, so a host can implement against it without
+//! linking the engine.
+//!
+//! ## Trusted config only
+//!
+//! [`ToolGrant::slug`], [`ToolGrant::connection_ref`], a node's `agent_ref`, and
+//! [`ContextSourceKind::Memory`]'s `scope` are **literals, never
+//! `=`-expressions**. An expression there would let upstream data — which may
+//! include model output — choose which credential a call acts as, which tool it
+//! reaches, or which agent type (and therefore which tool grants) a turn runs
+//! with. [`crate::validate`] rejects those structurally, before a run starts.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// A reusable agent type: what the agent is, what it may use, and how far it
+/// may go.
+///
+/// Every field but `id` defaults, so a definition can be as thin as
+/// `{"id": "researcher"}` — useful when the harness holds the real
+/// configuration and the graph only needs to name it.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct AgentDefinition {
+    /// Stable id an `agent` node's `agent_ref` selects, unique within a graph.
+    ///
+    /// Opaque to the engine: compared for equality and echoed back to the
+    /// harness, never parsed.
+    pub id: String,
+
+    /// Human-readable name for editors and pickers.
+    ///
+    /// Never an identity — resolve on [`id`](Self::id), never on this.
+    #[serde(default)]
+    pub name: String,
+
+    /// What this agent is for. Surfaced to authors, and passed to the harness
+    /// (which may show it to a delegating parent agent).
+    #[serde(default)]
+    pub description: String,
+
+    /// The agent's standing instructions — its contribution to the system
+    /// prompt.
+    ///
+    /// Passed to the harness verbatim. The engine never truncates it and never
+    /// composes a prompt of its own: prompt assembly belongs to whoever owns the
+    /// loop. May contain `=`-expressions, which the engine resolves first.
+    #[serde(default)]
+    pub instructions: Option<String>,
+
+    /// Preferred model id, opaque to the engine (`"claude-opus-5"`, a host
+    /// alias, whatever the harness understands).
+    ///
+    /// `None` means "no preference, the harness's default applies" — it does not
+    /// mean "no model". Encoding the fallback as absence keeps the choice of a
+    /// default with the only party that has credentials for one.
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// Preferred provider id, opaque to the engine (`"anthropic"`, a gateway
+    /// name, a host routing key).
+    ///
+    /// Carried separately from [`model`](Self::model) rather than folded into
+    /// it, because a harness routing the same model id through different
+    /// providers should not have to parse a composite string apart.
+    #[serde(default)]
+    pub provider: Option<String>,
+
+    /// Advisory ceilings on the harness's loop. See [`AgentLimits`].
+    #[serde(default)]
+    pub limits: AgentLimits,
+
+    /// The tools this agent type may use, before any node-level narrowing.
+    #[serde(default)]
+    pub tools: Vec<ToolGrant>,
+
+    /// Context composed into every run of this agent type, in declaration
+    /// order.
+    #[serde(default)]
+    pub context: Vec<ContextSource>,
+
+    /// Free-form passthrough for the harness: tier hints, sandbox policy, UI
+    /// affordances, anything this crate has no business modelling.
+    ///
+    /// The engine never interprets it — it merges node-level keys over these
+    /// and forwards the result on the request.
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+}
+
+impl AgentDefinition {
+    /// A definition carrying nothing but an id.
+    ///
+    /// This is what an unresolved `agent_ref` becomes: the harness receives the
+    /// id it was given and resolves the rest internally.
+    ///
+    /// ```
+    /// use tinyflows::model::AgentDefinition;
+    ///
+    /// let agent = AgentDefinition::new("researcher");
+    /// assert_eq!(agent.id, "researcher");
+    /// assert!(agent.tools.is_empty());
+    /// assert!(agent.model.is_none());
+    /// ```
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            ..Self::default()
+        }
+    }
+}
+
+/// Advisory bounds on a harness-owned agent loop.
+///
+/// **Advisory, not enforced.** The loop runs entirely host-side, so the engine
+/// never observes a step or a tool call and cannot enforce a cap on either.
+/// These are the author's declared intent, forwarded so the harness can apply
+/// them; a harness that ignores them is not violating a contract this crate
+/// could have checked. What the engine *does* enforce is its own
+/// `node_timeout_secs`, which bounds the whole capability call regardless.
+///
+/// A `None` field means "no author-declared bound", not "unbounded" — the
+/// harness's own default applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct AgentLimits {
+    /// Maximum model↔tool iterations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_steps: Option<u32>,
+    /// Maximum individual tool invocations across the run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tool_calls: Option<u32>,
+    /// Wall-clock budget, in seconds, for the whole agent run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_seconds: Option<u32>,
+}
+
+impl AgentLimits {
+    /// Whether no bound at all is declared.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.max_steps.is_none() && self.max_tool_calls.is_none() && self.max_seconds.is_none()
+    }
+
+    /// Narrows `self` by `other`, taking the **lower** of each declared bound.
+    ///
+    /// Used to apply a node's limits to its agent definition's: a node may only
+    /// tighten a ceiling the definition set, never raise it, so a curated agent
+    /// type cannot be widened by the graph that uses it.
+    ///
+    /// ```
+    /// use tinyflows::model::AgentLimits;
+    ///
+    /// let definition = AgentLimits { max_steps: Some(8), max_tool_calls: Some(20), max_seconds: None };
+    /// let node = AgentLimits { max_steps: Some(4), max_tool_calls: Some(99), max_seconds: Some(30) };
+    ///
+    /// let merged = definition.narrowed_by(&node);
+    /// assert_eq!(merged.max_steps, Some(4));       // node tightened it
+    /// assert_eq!(merged.max_tool_calls, Some(20)); // node tried to widen it; ignored
+    /// assert_eq!(merged.max_seconds, Some(30));    // only the node declared one
+    /// ```
+    #[must_use]
+    pub fn narrowed_by(&self, other: &Self) -> Self {
+        /// The lower of two optional bounds, or whichever one is declared.
+        fn lower(a: Option<u32>, b: Option<u32>) -> Option<u32> {
+            match (a, b) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (some, None) | (None, some) => some,
+            }
+        }
+        Self {
+            max_steps: lower(self.max_steps, other.max_steps),
+            max_tool_calls: lower(self.max_tool_calls, other.max_tool_calls),
+            max_seconds: lower(self.max_seconds, other.max_seconds),
+        }
+    }
+}
+
+/// A tool an agent is permitted to call.
+///
+/// A grant is *intent*, not a descriptor: it names a tool but carries no
+/// argument schema, because an author does not write one. The harness turns
+/// grants into concrete
+/// [`ToolDescriptor`](crate::caps::ToolDescriptor)s through
+/// [`AgentRunner::resolve_tools`](crate::caps::AgentRunner::resolve_tools).
+///
+/// This is a strict superset of the `{"slug": …, "connection_ref": …}` objects
+/// an `agent` node's `config.tools` already carried, so existing graphs
+/// deserialize unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ToolGrant {
+    /// The tool identifier the harness resolves — an exact slug
+    /// (`"github.add_labels"`), or a namespace pattern with a trailing `.*`
+    /// (`"github.*"`).
+    ///
+    /// The engine performs no matching of its own beyond exact-equality subset
+    /// checks; expanding a pattern is the harness's job, and a harness that does
+    /// not expand receives the pattern verbatim.
+    ///
+    /// A **literal**, never an `=`-expression: a tool chosen by run data is a
+    /// tool chosen by whatever wrote that data.
+    pub slug: String,
+
+    /// Trusted connection reference for calls to this tool, overriding the
+    /// node's.
+    ///
+    /// Trusted config only — a model-supplied connection reference is never
+    /// honored, since it would let a prompt injection point a call at an
+    /// arbitrary host credential.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_ref: Option<String>,
+}
+
+impl ToolGrant {
+    /// A grant for `slug` with no connection override.
+    #[must_use]
+    pub fn new(slug: impl Into<String>) -> Self {
+        Self {
+            slug: slug.into(),
+            connection_ref: None,
+        }
+    }
+
+    /// Whether this grant is a trailing-`.*` namespace pattern rather than an
+    /// exact slug.
+    ///
+    /// ```
+    /// use tinyflows::model::ToolGrant;
+    ///
+    /// assert!(ToolGrant::new("github.*").is_pattern());
+    /// assert!(!ToolGrant::new("github.add_labels").is_pattern());
+    /// ```
+    #[must_use]
+    pub fn is_pattern(&self) -> bool {
+        self.slug.ends_with(".*")
+    }
+
+    /// Whether this grant covers `slug` — by exact match, or by namespace when
+    /// this grant is a pattern.
+    ///
+    /// ```
+    /// use tinyflows::model::ToolGrant;
+    ///
+    /// assert!(ToolGrant::new("github.*").covers("github.add_labels"));
+    /// assert!(!ToolGrant::new("github.*").covers("slack.post"));
+    /// assert!(ToolGrant::new("slack.post").covers("slack.post"));
+    /// ```
+    #[must_use]
+    pub fn covers(&self, slug: &str) -> bool {
+        match self.slug.strip_suffix('*') {
+            Some(prefix) => slug.starts_with(prefix),
+            None => self.slug == slug,
+        }
+    }
+}
+
+/// One declared source of dynamic context for an agent turn.
+///
+/// Context is *declarative*: the author says where material comes from, and the
+/// engine resolves each source into a
+/// [`ContextBlock`](crate::caps::ContextBlock) at request-assembly time. The
+/// engine never reorders, merges, de-duplicates, or truncates blocks — composing
+/// them into a prompt is the harness's job.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContextSource {
+    /// Stable label for this block, used in the assembled request and in
+    /// diagnostics so an author can tell which block failed to resolve. A
+    /// generated `"context_<n>"` is used when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+
+    /// Where the material comes from.
+    #[serde(flatten)]
+    pub kind: ContextSourceKind,
+
+    /// Whether this block is survivable when it cannot be resolved.
+    ///
+    /// **Defaults to `false`, and that default is load-bearing.** An agent
+    /// silently missing its identity text, or the list of integrations the user
+    /// has actually connected, still runs and produces confident, wrong output —
+    /// a failure that passes a smoke test. So an unresolvable block fails the
+    /// node unless the author explicitly said it was optional.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub optional: bool,
+}
+
+impl ContextSource {
+    /// A required context source of the given kind, with no label.
+    #[must_use]
+    pub fn new(kind: ContextSourceKind) -> Self {
+        Self {
+            label: None,
+            kind,
+            optional: false,
+        }
+    }
+
+    /// This source's label, or the positional fallback `"context_<index>"`.
+    #[must_use]
+    pub fn label_or_index(&self, index: usize) -> String {
+        self.label
+            .clone()
+            .unwrap_or_else(|| format!("context_{index}"))
+    }
+}
+
+/// Where a [`ContextSource`]'s material comes from.
+///
+/// Closed on purpose: an author may not name an arbitrary resolution mechanism,
+/// because a config string that chooses what the engine executes is a second,
+/// unreviewed dispatch table. Four kinds resolve against capabilities this crate
+/// already has; only [`Host`](ContextSourceKind::Host) reaches the harness for
+/// something the engine cannot produce.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ContextSourceKind {
+    /// Literal text, or an `=`-expression resolved against the node's usual
+    /// scope (`item` / `items` / `nodes` / `inputs` / `run`) before assembly.
+    ///
+    /// The workhorse: `{"kind": "text", "text": "=nodes.fetch.item.json.body"}`
+    /// hands an agent an upstream node's output as prose.
+    Text {
+        /// The block body, literal or `=`-expression.
+        text: String,
+    },
+
+    /// The node's input items, as a JSON array — the commonest way to hand an
+    /// agent the rows the workflow just produced.
+    Items,
+
+    /// A recall against the host's memory store, through the **existing**
+    /// [`MemoryProvider`](crate::caps::MemoryProvider) capability.
+    ///
+    /// No new capability is introduced for this: a memory-backed context block
+    /// is precisely a `recall`, and a second trait that also read memory would
+    /// give the `scope` contract two places to drift. Read-only by construction
+    /// — there is no context source that writes.
+    Memory {
+        /// Host-defined memory scope: `"user"`, `"flow"`, or `"flows"`. A
+        /// **literal**, never an `=`-expression, matching the `memory` node.
+        scope: String,
+        /// Free-text recall query; may be an `=`-expression.
+        query: String,
+        /// Maximum results to fold into the block.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        limit: Option<u32>,
+    },
+
+    /// A named host "flavour" profile (an ask/persona/style record), through
+    /// [`MemoryProvider::flavour`](crate::caps::MemoryProvider::flavour).
+    Flavour {
+        /// The flavour slug.
+        slug: String,
+    },
+
+    /// An opaque, host-named source the harness expands: identity/soul text,
+    /// a description of the integrations this user has connected, a RAG index,
+    /// learned context.
+    ///
+    /// The engine resolves any `=`-expressions inside `params` and then hands
+    /// the reference to
+    /// [`AgentRunner::resolve_context`](crate::caps::AgentRunner::resolve_context);
+    /// it knows nothing about `source` beyond that the harness may recognize it.
+    Host {
+        /// Host-defined source id. Opaque; the engine never parses it.
+        source: String,
+        /// Host-defined parameters, forwarded after expression resolution.
+        #[serde(default, skip_serializing_if = "Value::is_null")]
+        params: Value,
+    },
+}
+
+impl ContextSourceKind {
+    /// The `snake_case` wire name of this kind, as it appears in JSON and on the
+    /// assembled [`ContextBlock`](crate::caps::ContextBlock).
+    ///
+    /// ```
+    /// use tinyflows::model::ContextSourceKind;
+    ///
+    /// assert_eq!(ContextSourceKind::Items.as_str(), "items");
+    /// ```
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Text { .. } => "text",
+            Self::Items => "items",
+            Self::Memory { .. } => "memory",
+            Self::Flavour { .. } => "flavour",
+            Self::Host { .. } => "host",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn a_definition_needs_only_an_id() {
+        let agent: AgentDefinition = serde_json::from_value(json!({ "id": "researcher" })).unwrap();
+        assert_eq!(agent, AgentDefinition::new("researcher"));
+    }
+
+    #[test]
+    fn a_full_definition_round_trips() {
+        let wire = json!({
+            "id": "triager",
+            "name": "Issue triager",
+            "description": "Labels and routes inbound issues.",
+            "instructions": "Be terse.",
+            "model": "claude-opus-5",
+            "provider": "anthropic",
+            "limits": { "max_steps": 8, "max_tool_calls": 20 },
+            "tools": [
+                { "slug": "github.search_issues" },
+                { "slug": "github.add_labels", "connection_ref": "conn_gh_bot" }
+            ],
+            "context": [
+                { "kind": "memory", "scope": "user", "query": "triage preferences", "limit": 5 },
+                { "kind": "host", "source": "repo_conventions", "params": { "repo": "=inputs.repo" } }
+            ],
+            "metadata": { "tier": "fast" }
+        });
+        let agent: AgentDefinition = serde_json::from_value(wire.clone()).unwrap();
+
+        assert_eq!(agent.provider.as_deref(), Some("anthropic"));
+        assert_eq!(agent.limits.max_steps, Some(8));
+        assert_eq!(agent.tools.len(), 2);
+        assert_eq!(agent.context[0].kind.as_str(), "memory");
+        assert_eq!(agent.metadata.get("tier"), Some(&json!("fast")));
+
+        // Optional/absent fields are elided, so a round trip is byte-stable.
+        assert_eq!(serde_json::to_value(&agent).unwrap(), wire);
+    }
+
+    #[test]
+    fn todays_tool_descriptor_shape_still_deserializes() {
+        // The `{slug, connection_ref}` objects existing `agent` node configs
+        // already carry must load as grants unchanged.
+        let grants: Vec<ToolGrant> = serde_json::from_value(json!([
+            { "slug": "SOME_TOOL_ACTION" },
+            { "slug": "OTHER_ACTION", "connection_ref": "acct_9" }
+        ]))
+        .unwrap();
+        assert_eq!(grants[0], ToolGrant::new("SOME_TOOL_ACTION"));
+        assert_eq!(grants[1].connection_ref.as_deref(), Some("acct_9"));
+    }
+
+    #[test]
+    fn a_context_source_flattens_its_kind() {
+        let source: ContextSource =
+            serde_json::from_value(json!({ "kind": "text", "text": "hello", "label": "Greeting" }))
+                .unwrap();
+        assert_eq!(source.label.as_deref(), Some("Greeting"));
+        assert!(!source.optional, "sources are required by default");
+        assert_eq!(source.kind, ContextSourceKind::Text { text: "hello".into() });
+    }
+
+    #[test]
+    fn a_unit_kind_needs_no_payload() {
+        let source: ContextSource = serde_json::from_value(json!({ "kind": "items" })).unwrap();
+        assert_eq!(source.kind, ContextSourceKind::Items);
+        assert_eq!(source.label_or_index(2), "context_2");
+    }
+
+    #[test]
+    fn limits_narrow_but_never_widen() {
+        let definition = AgentLimits {
+            max_steps: Some(8),
+            max_tool_calls: Some(20),
+            max_seconds: None,
+        };
+        let node = AgentLimits {
+            max_steps: Some(4),
+            max_tool_calls: Some(99),
+            max_seconds: Some(30),
+        };
+        assert_eq!(
+            definition.narrowed_by(&node),
+            AgentLimits {
+                max_steps: Some(4),
+                max_tool_calls: Some(20),
+                max_seconds: Some(30),
+            }
+        );
+        assert!(AgentLimits::default().is_empty());
+    }
+
+    #[test]
+    fn a_pattern_grant_covers_its_namespace_only() {
+        let grant = ToolGrant::new("github.*");
+        assert!(grant.is_pattern());
+        assert!(grant.covers("github.add_labels"));
+        assert!(!grant.covers("gitlab.add_labels"));
+        assert!(!ToolGrant::new("github.add_labels").covers("github.search"));
+    }
+}

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -160,6 +160,12 @@ impl AgentDefinition {
 ///
 /// A `None` field means "no author-declared bound", not "unbounded" — the
 /// harness's own default applies.
+///
+/// The two timeouts are separate on purpose. A whole-run budget cannot express
+/// "no single tool call may hang for more than 30s", and a per-tool timeout
+/// cannot express "give up on this agent after five minutes" — a loop making
+/// steady, individually-fast tool calls runs forever under a per-tool bound
+/// alone.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct AgentLimits {
     /// Maximum model↔tool iterations.
@@ -168,16 +174,27 @@ pub struct AgentLimits {
     /// Maximum individual tool invocations across the run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_tool_calls: Option<u32>,
-    /// Wall-clock budget, in seconds, for the whole agent run.
+    /// Wall-clock budget, in seconds, for the **whole agent run** — every model
+    /// call, every tool call, and the harness's own overhead between them.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_seconds: Option<u32>,
+    pub agent_timeout_secs: Option<u32>,
+    /// Wall-clock budget, in seconds, for a **single tool invocation**.
+    ///
+    /// Bounds each call independently, so one wedged tool cannot consume the
+    /// whole agent budget. How a harness reports the timeout to the model — as a
+    /// tool error it can recover from, or as a hard stop — is its own policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_timeout_secs: Option<u32>,
 }
 
 impl AgentLimits {
     /// Whether no bound at all is declared.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.max_steps.is_none() && self.max_tool_calls.is_none() && self.max_seconds.is_none()
+        self.max_steps.is_none()
+            && self.max_tool_calls.is_none()
+            && self.agent_timeout_secs.is_none()
+            && self.tool_timeout_secs.is_none()
     }
 
     /// Narrows `self` by `other`, taking the **lower** of each declared bound.

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -101,7 +101,7 @@ pub struct AgentDefinition {
     /// motivating case — so a harness must validate it against whatever roots it
     /// permits before handing it to a process, rather than assuming the engine
     /// vetted it.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
 
     /// Advisory ceilings on the harness's loop. See [`AgentLimits`].

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -358,12 +358,40 @@ impl ContextSource {
         }
     }
 
-    /// This source's label, or the positional fallback `"context_<index>"`.
+    /// This source's label, or the best available fallback.
+    ///
+    /// An unlabelled source falls back to whatever identifies it — a host
+    /// source's name, a flavour's slug, a memory scope — and only to the
+    /// positional `"context_<index>"` when the kind carries no identifier of its
+    /// own. That fallback is what an author sees in a "could not be resolved"
+    /// error, and `context_0` does not tell them which block to go fix.
+    ///
+    /// ```
+    /// use tinyflows::model::{ContextSource, ContextSourceKind};
+    /// use serde_json::Value;
+    ///
+    /// let host = ContextSource::new(ContextSourceKind::Host {
+    ///     source: "repo_conventions".into(),
+    ///     params: Value::Null,
+    /// });
+    /// assert_eq!(host.label_or_index(0), "repo_conventions");
+    ///
+    /// // A kind with nothing to name itself by falls back to its position.
+    /// assert_eq!(ContextSource::new(ContextSourceKind::Items).label_or_index(3), "context_3");
+    /// ```
     #[must_use]
     pub fn label_or_index(&self, index: usize) -> String {
-        self.label
-            .clone()
-            .unwrap_or_else(|| format!("context_{index}"))
+        if let Some(label) = &self.label {
+            return label.clone();
+        }
+        match &self.kind {
+            ContextSourceKind::Host { source, .. } => source.clone(),
+            ContextSourceKind::Flavour { slug } => slug.clone(),
+            ContextSourceKind::Memory { scope, .. } => format!("memory:{scope}"),
+            ContextSourceKind::Text { .. } | ContextSourceKind::Items => {
+                format!("context_{index}")
+            }
+        }
     }
 }
 

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -206,13 +206,20 @@ impl AgentLimits {
     /// ```
     /// use tinyflows::model::AgentLimits;
     ///
-    /// let definition = AgentLimits { max_steps: Some(8), max_tool_calls: Some(20), max_seconds: None };
-    /// let node = AgentLimits { max_steps: Some(4), max_tool_calls: Some(99), max_seconds: Some(30) };
+    /// let definition = AgentLimits {
+    ///     max_steps: Some(8), max_tool_calls: Some(20),
+    ///     agent_timeout_secs: None, tool_timeout_secs: Some(60),
+    /// };
+    /// let node = AgentLimits {
+    ///     max_steps: Some(4), max_tool_calls: Some(99),
+    ///     agent_timeout_secs: Some(30), tool_timeout_secs: None,
+    /// };
     ///
     /// let merged = definition.narrowed_by(&node);
-    /// assert_eq!(merged.max_steps, Some(4));       // node tightened it
-    /// assert_eq!(merged.max_tool_calls, Some(20)); // node tried to widen it; ignored
-    /// assert_eq!(merged.max_seconds, Some(30));    // only the node declared one
+    /// assert_eq!(merged.max_steps, Some(4));            // node tightened it
+    /// assert_eq!(merged.max_tool_calls, Some(20));      // node tried to widen it; ignored
+    /// assert_eq!(merged.agent_timeout_secs, Some(30));  // only the node declared one
+    /// assert_eq!(merged.tool_timeout_secs, Some(60));   // only the definition declared one
     /// ```
     #[must_use]
     pub fn narrowed_by(&self, other: &Self) -> Self {
@@ -226,7 +233,8 @@ impl AgentLimits {
         Self {
             max_steps: lower(self.max_steps, other.max_steps),
             max_tool_calls: lower(self.max_tool_calls, other.max_tool_calls),
-            max_seconds: lower(self.max_seconds, other.max_seconds),
+            agent_timeout_secs: lower(self.agent_timeout_secs, other.agent_timeout_secs),
+            tool_timeout_secs: lower(self.tool_timeout_secs, other.tool_timeout_secs),
         }
     }
 }
@@ -524,19 +532,22 @@ mod tests {
         let definition = AgentLimits {
             max_steps: Some(8),
             max_tool_calls: Some(20),
-            max_seconds: None,
+            agent_timeout_secs: None,
+            tool_timeout_secs: Some(60),
         };
         let node = AgentLimits {
             max_steps: Some(4),
             max_tool_calls: Some(99),
-            max_seconds: Some(30),
+            agent_timeout_secs: Some(30),
+            tool_timeout_secs: Some(90),
         };
         assert_eq!(
             definition.narrowed_by(&node),
             AgentLimits {
                 max_steps: Some(4),
                 max_tool_calls: Some(20),
-                max_seconds: Some(30),
+                agent_timeout_secs: Some(30),
+                tool_timeout_secs: Some(60),
             }
         );
         assert!(AgentLimits::default().is_empty());

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -384,7 +384,15 @@ pub enum ContextSourceKind {
     /// hands an agent an upstream node's output as prose.
     Text {
         /// The block body, literal or `=`-expression.
-        text: String,
+        ///
+        /// Typed as a [`Value`] rather than a `String` because an expression
+        /// resolves to whatever the data holds: `"=item.count"` yields a number
+        /// and `"=item.record"` an object. Rejecting those would make the
+        /// commonest binding in the whole feature fail on a type the author
+        /// never wrote. A non-string value is rendered as compact JSON for the
+        /// block's `text` and carried structurally in its `data`, so a harness
+        /// can use whichever it prefers.
+        text: Value,
     },
 
     /// The node's input items, as a JSON array — the commonest way to hand an
@@ -517,7 +525,12 @@ mod tests {
                 .unwrap();
         assert_eq!(source.label.as_deref(), Some("Greeting"));
         assert!(!source.optional, "sources are required by default");
-        assert_eq!(source.kind, ContextSourceKind::Text { text: "hello".into() });
+        assert_eq!(
+            source.kind,
+            ContextSourceKind::Text {
+                text: Value::from("hello")
+            }
+        );
     }
 
     #[test]

--- a/src/model/agent.rs
+++ b/src/model/agent.rs
@@ -88,6 +88,22 @@ pub struct AgentDefinition {
     #[serde(default)]
     pub provider: Option<String>,
 
+    /// Working directory the agent should run in, when it runs somewhere with a
+    /// filesystem — a repo checkout, a sandbox root, a scratch workspace.
+    ///
+    /// Optional and opaque: the engine never touches the filesystem, never
+    /// canonicalizes this, and never checks that it exists. `None` means "no
+    /// author preference"; the harness's own default applies.
+    ///
+    /// This is **untrusted authoring input**, exactly like the path fields on
+    /// [`ShellRequest`](crate::caps::ShellRequest). It may be an
+    /// `=`-expression — a checkout path produced by an upstream node is the
+    /// motivating case — so a harness must validate it against whatever roots it
+    /// permits before handing it to a process, rather than assuming the engine
+    /// vetted it.
+    #[serde(default)]
+    pub working_dir: Option<String>,
+
     /// Advisory ceilings on the harness's loop. See [`AgentLimits`].
     #[serde(default)]
     pub limits: AgentLimits,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -190,6 +190,7 @@ impl Default for WorkflowGraph {
             id: None,
             name: String::new(),
             inputs: Vec::new(),
+            agents: Vec::new(),
             nodes: Vec::new(),
             edges: Vec::new(),
         }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -21,6 +21,13 @@
 //! A graph also declares its parameters — see [`WorkflowInput`] and
 //! [`resolve_inputs`]. They are the workflow's public signature, validated
 //! before a run starts and addressed from node config as `=inputs.<name>`.
+//!
+//! ## Agents
+//!
+//! A graph may also declare reusable **agent types** — see [`AgentDefinition`]
+//! and [`WorkflowGraph::agents`]. An `agent` node selects one by `agent_ref` and
+//! may narrow it (tighter limits, fewer tools, extra instructions), so one
+//! definition serves many nodes and travels with the workflow between hosts.
 
 mod agent;
 mod inputs;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -160,6 +160,19 @@ pub struct WorkflowGraph {
     /// configuration as `=inputs.<name>`.
     #[serde(default)]
     pub inputs: Vec<WorkflowInput>,
+    /// Reusable **agent types** this workflow declares — its own agent
+    /// registry, mirroring [`inputs`](Self::inputs).
+    ///
+    /// An `agent` node's `config.agent_ref` resolves here first, so a workflow
+    /// that carries its own definitions behaves identically on every host. A ref
+    /// this registry does not declare falls back to the harness's own registry
+    /// (see [`AgentRunner::resolve_agent`](crate::caps::AgentRunner::resolve_agent)),
+    /// and a ref neither resolves is passed through to the harness as an id.
+    ///
+    /// Empty for graphs authored before the registry existed, and for graphs
+    /// whose agents are entirely host-defined.
+    #[serde(default)]
+    pub agents: Vec<AgentDefinition>,
     /// The nodes in the graph.
     #[serde(default)]
     pub nodes: Vec<Node>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -232,6 +232,27 @@ impl WorkflowGraph {
         self.nodes.iter().find(|n| n.id == id)
     }
 
+    /// Looks up an in-graph [`AgentDefinition`] by id.
+    ///
+    /// Returns `None` when the graph declares no such agent — a normal outcome,
+    /// not a failure: the `agent` node then falls back to the harness's registry
+    /// and finally to passing the ref through as an id.
+    ///
+    /// ```
+    /// use tinyflows::model::WorkflowGraph;
+    ///
+    /// let graph: WorkflowGraph = serde_json::from_str(
+    ///     r#"{"agents":[{"id":"triager","model":"claude-opus-5"}],"nodes":[],"edges":[]}"#,
+    /// )
+    /// .unwrap();
+    /// assert_eq!(graph.agent("triager").unwrap().model.as_deref(), Some("claude-opus-5"));
+    /// assert!(graph.agent("nobody").is_none());
+    /// ```
+    #[must_use]
+    pub fn agent(&self, id: &str) -> Option<&AgentDefinition> {
+        self.agents.iter().find(|a| a.id == id)
+    }
+
     /// Returns the ids of the **direct** successors of `start` — the target node
     /// of each edge leaving it (immediate neighbors only, not the transitive
     /// closure; ids may repeat if multiple edges connect the same pair).

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -22,9 +22,13 @@
 //! [`resolve_inputs`]. They are the workflow's public signature, validated
 //! before a run starts and addressed from node config as `=inputs.<name>`.
 
+mod agent;
 mod inputs;
 mod node_kind;
 
+pub use agent::{
+    AgentDefinition, AgentLimits, ContextSource, ContextSourceKind, ToolGrant,
+};
 pub use inputs::{InputError, InputType, WorkflowInput, is_valid_input_name, resolve_inputs};
 pub use node_kind::{NodeKind, TriggerKind};
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -33,9 +33,7 @@ mod agent;
 mod inputs;
 mod node_kind;
 
-pub use agent::{
-    AgentDefinition, AgentLimits, ContextSource, ContextSourceKind, ToolGrant,
-};
+pub use agent::{AgentDefinition, AgentLimits, ContextSource, ContextSourceKind, ToolGrant};
 pub use inputs::{InputError, InputType, WorkflowInput, is_valid_input_name, resolve_inputs};
 pub use node_kind::{NodeKind, TriggerKind};
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -318,6 +318,7 @@ mod tests {
                     .with_default(serde_json::json!(3))
                     .with_description("How deep to recurse"),
             ],
+            agents: Vec::new(),
             nodes: vec![node("t", NodeKind::Trigger), node("a", NodeKind::Agent)],
             edges: vec![Edge {
                 from_node: "t".to_string(),
@@ -469,6 +470,7 @@ mod tests {
             id: Some("wf_1".to_string()),
             name: "demo".to_string(),
             inputs: Vec::new(),
+            agents: Vec::new(),
             nodes: vec![Node {
                 id: "t".to_string(),
                 kind: NodeKind::Trigger,

--- a/src/nodes/control_flow/condition.rs
+++ b/src/nodes/control_flow/condition.rs
@@ -89,6 +89,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/control_flow/dedup.rs
+++ b/src/nodes/control_flow/dedup.rs
@@ -325,6 +325,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/control_flow/loop_node.rs
+++ b/src/nodes/control_flow/loop_node.rs
@@ -180,6 +180,7 @@ mod tests {
                 run: &Value::Null,
                 nodes: &nodes,
                 caps: &caps,
+                agents: &[],
                 observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             })

--- a/src/nodes/control_flow/merge.rs
+++ b/src/nodes/control_flow/merge.rs
@@ -53,6 +53,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -73,6 +74,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/control_flow/split_out.rs
+++ b/src/nodes/control_flow/split_out.rs
@@ -88,6 +88,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -112,6 +113,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -135,6 +137,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -155,6 +158,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/control_flow/switch.rs
+++ b/src/nodes/control_flow/switch.rs
@@ -91,6 +91,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -114,6 +115,7 @@ mod tests {
             run: &run,
             nodes: &nodes,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/control_flow/transform.rs
+++ b/src/nodes/control_flow/transform.rs
@@ -86,6 +86,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -112,6 +113,7 @@ mod tests {
             run: &run,
             nodes: &nodes,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -29,15 +29,37 @@ use crate::nodes::{NodeContext, NodeExecutor, NodeOutput};
 ///   (validate → one LLM auto-fix → re-validate), honoring
 ///   `config.output_parser.auto_fix` (default `true`).
 ///
-/// **Agent-kind selection** (`config.agent_ref`): when set to a host-registered
-/// agent id and the host wired the optional [`AgentRunner`](crate::caps::AgentRunner)
-/// capability, the node runs that named agent — with its own curated tools,
-/// model, and sandbox — to completion, instead of a bare completion. The inline
-/// tool sub-port is then skipped (the registered agent owns its tool loop); the
-/// output-parser sub-port still applies. `agent_ref` is read from trusted node
-/// config, never from model output. With no `agent_ref` (or no `AgentRunner`),
-/// the node falls back to [`LlmProvider`](crate::caps::LlmProvider). Either way
-/// the output is the same `{ json, text, raw }` envelope.
+/// **Agent-kind selection** (`config.agent_ref`): when set and the host wired the
+/// optional [`AgentRunner`](crate::caps::AgentRunner) capability, the node runs
+/// that named agent to completion instead of issuing a bare completion.
+/// `agent_ref` resolves against the graph's own
+/// [`agents`](crate::model::WorkflowGraph::agents) registry first, then the
+/// harness's, then passes through as a bare id. The resulting
+/// [`AgentDefinition`](crate::model::AgentDefinition) is merged with the node's
+/// overrides — **narrowing only** — and assembled into a typed
+/// [`AgentRunRequest`](crate::caps::AgentRunRequest) carrying the resolved
+/// instructions, model, provider, working directory, context blocks, tool
+/// descriptors, limits, and metadata. See
+/// [`agent_request`](super::agent_request) for the merge rules.
+///
+/// The inline tool sub-port is skipped on that path (the agent owns its own tool
+/// loop, and re-invoking a tool it already called would duplicate the side
+/// effect); the output-parser sub-port still applies. `agent_ref` is read from
+/// trusted node config, never from model output.
+///
+/// With no `agent_ref` (or no `AgentRunner`) the node falls back to
+/// [`LlmProvider`](crate::caps::LlmProvider) exactly as it always has — the one
+/// addition being that a declared `context` is still resolved into blocks, so an
+/// author's context is not silently dropped on a host without a harness.
+///
+/// **Output.** The agent-kind path emits `{ json, text, raw, meta }`, where
+/// `meta.stop` is `"finished"` or `"limit_stop"` — so a downstream `condition`
+/// can branch on whether the agent actually reached an answer. A `limit_stop`
+/// payload is partial and skips the output parser. The degraded path emits the
+/// original three-key envelope unchanged. A harness reporting
+/// [`Paused`](crate::caps::StopReason::Paused) fails the node: resuming a paused
+/// agent is not supported yet, and emitting a half-run agent's output as if it
+/// were an answer is the failure this refuses to make.
 ///
 /// Sub-ports **not** yet wired (documented follow-ups): a `chat_model` sub-port
 /// (attached model selection beyond what the request already carries) and a

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -93,7 +93,18 @@ impl NodeExecutor for AgentNode {
 /// registered agent kind), the optional tool sub-port, the optional
 /// output-parser sub-port, and finally the stable `{ json, text, raw }`
 /// envelope. Returns the emitted [`Item`] (without pairing — the caller sets it).
-async fn run_turn(ctx: &NodeContext<'_>, cfg: &Value) -> Result<Item> {
+async fn run_turn(ctx: &NodeContext<'_>, cfg: &Value, scope: &Value) -> Result<Item> {
+    run_turn_indexed(ctx, cfg, scope, None).await
+}
+
+/// [`run_turn`], told which input item it is running for under `per_item`
+/// execution, so the harness can attribute the run.
+async fn run_turn_indexed(
+    ctx: &NodeContext<'_>,
+    cfg: &Value,
+    scope: &Value,
+    item_index: Option<usize>,
+) -> Result<Item> {
     let conn = cfg.get("connection_ref").and_then(Value::as_str);
 
     // Agent-kind selection: a trusted `agent_ref` in config routes this node
@@ -102,23 +113,22 @@ async fn run_turn(ctx: &NodeContext<'_>, cfg: &Value) -> Result<Item> {
     // comes from resolved node config — never from model output — so it can't
     // be steered by prompt injection. Falls back to `LlmProvider` when no
     // `agent_ref` is set or the host wired no agent registry.
-    let agent_ref = cfg
-        .get("agent_ref")
-        .and_then(Value::as_str)
-        .filter(|s| !s.is_empty());
+    let agent_ref = super::agent_request::agent_ref_of(cfg);
     let via_agent_kind = agent_ref.is_some() && ctx.caps.agent.is_some();
-    let response = match (agent_ref, ctx.caps.agent.as_ref()) {
-        (Some(agent_ref), Some(runner)) => {
-            tracing::debug!(agent_ref, "agent node: running registered agent kind");
-            runner.run_agent(agent_ref, cfg.clone(), conn).await?
-        }
-        _ => {
-            // The node config *is* the completion request; when a `tools`
-            // sub-port is configured its descriptors ride along so the model
-            // can elect to call one.
-            ctx.caps.llm.complete(cfg.clone(), conn).await?
-        }
-    };
+
+    if let (Some(agent_ref), Some(runner)) = (agent_ref, ctx.caps.agent.as_ref()) {
+        tracing::debug!(agent_ref, "agent node: running registered agent kind");
+        let request =
+            super::agent_request::assemble(ctx, cfg, agent_ref, scope, item_index).await?;
+        let outcome = runner.run(request).await?;
+        return finish_agent_run(ctx, cfg, conn, agent_ref, outcome).await;
+    }
+
+    // Degraded path: no agent kind selected, or no harness wired. The node
+    // config *is* the completion request, exactly as it has always been — when
+    // a `tools` sub-port is configured its descriptors ride along so the model
+    // can elect to call one.
+    let response = ctx.caps.llm.complete(cfg.clone(), conn).await?;
 
     // `text`/`raw` are derived from the untouched completion; `value` is the
     // structured payload we thread the sub-ports (tool hop, output parser)

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -70,11 +70,13 @@ impl NodeExecutor for AgentNode {
                 ctx.observer,
                 opts,
                 move |index| async move {
-                    let (cfg, diags) = crate::nodes::resolve_config_traced_for_item(
-                        ctx,
-                        ctx.input[index].json.clone(),
-                    );
-                    let item = run_turn(ctx, &cfg).await?;
+                    let item_json = ctx.input[index].json.clone();
+                    let (cfg, diags) =
+                        crate::nodes::resolve_config_traced_for_item(ctx, item_json.clone());
+                    // The same scope the config was resolved against, so an
+                    // agent definition's own `=`-expressions see this item.
+                    let scope = crate::nodes::expr_scope_for(ctx, item_json);
+                    let item = run_turn_indexed(ctx, &cfg, &scope, Some(index)).await?;
                     Ok((item, diags))
                 },
             )
@@ -84,7 +86,8 @@ impl NodeExecutor for AgentNode {
 
         // Single turn against the first-item scope (or empty input).
         let (cfg, diagnostics) = crate::nodes::resolve_config_traced(&ctx);
-        let item = run_turn(&ctx, &cfg).await?;
+        let scope = crate::nodes::expr_scope(&ctx);
+        let item = run_turn(&ctx, &cfg, &scope).await?;
         Ok(NodeOutput::main(vec![item]).with_diagnostics(diagnostics))
     }
 }

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -803,4 +803,334 @@ mod tests {
         assert_eq!(value["json"]["completion"]["prompt"], "hi");
         assert!(value["json"].get("tool_result").is_none());
     }
+
+    // ---- configurable agents: registry, merge, context, tools, stop reasons --
+
+    mod configurable {
+        use super::{agent_node, run_agent};
+        use crate::caps::mock::{
+            MockAgentHarness, MockLimitedAgentRunner, MockPausingAgentRunner,
+            mock_capabilities_with_agent,
+        };
+        use crate::caps::{AgentRunner, Capabilities};
+        use crate::data::Item;
+        use crate::model::{AgentDefinition, AgentLimits, ContextSource, ContextSourceKind, ToolGrant};
+        use crate::nodes::{NodeContext, NodeExecutor};
+        use serde_json::{Value, json};
+
+        fn triager() -> AgentDefinition {
+            AgentDefinition {
+                id: "triager".into(),
+                instructions: Some("Be terse.".into()),
+                model: Some("sonnet".into()),
+                provider: Some("anthropic".into()),
+                working_dir: Some("/srv/checkout".into()),
+                limits: AgentLimits {
+                    max_steps: Some(8),
+                    max_tool_calls: Some(20),
+                    agent_timeout_secs: Some(300),
+                    tool_timeout_secs: Some(30),
+                },
+                tools: vec![
+                    ToolGrant::new("github.search"),
+                    ToolGrant {
+                        slug: "github.label".into(),
+                        connection_ref: Some("conn_definition".into()),
+                    },
+                ],
+                metadata: json!({ "tier": "fast" }).as_object().unwrap().clone(),
+                ..Default::default()
+            }
+        }
+
+        /// Runs an `agent` node against an in-graph registry and a typed harness.
+        async fn run_with_registry(
+            config: Value,
+            agents: &[AgentDefinition],
+            caps: &Capabilities,
+        ) -> Value {
+            let node = agent_node(config);
+            let input = vec![Item::new(json!({ "seed": 1 }))];
+            let run_meta = json!({ "run_id": "run_7", "sub_workflow_depth": 2 });
+            let out = super::super::AgentNode
+                .execute(NodeContext {
+                    node: &node,
+                    input: &input,
+                    run: &run_meta,
+                    nodes: &Value::Null,
+                    caps,
+                    agents,
+                    observer: &crate::observability::NoopObserver,
+                    token: crate::engine::CancellationToken::new(),
+                })
+                .await
+                .expect("execute");
+            out.items[0].json.clone()
+        }
+
+        #[tokio::test]
+        async fn an_in_graph_definition_reaches_the_harness_merged_with_node_overrides() {
+            let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+            let value = run_with_registry(
+                json!({
+                    "agent_ref": "triager",
+                    "prompt": "Triage it.",
+                    "instructions": "Prefer `bug`.",
+                    "model": "opus",
+                    "working_dir": "/srv/other",
+                    "tools": [{ "slug": "github.search" }],
+                    "limits": { "max_steps": 4 },
+                    "metadata": { "extra": true }
+                }),
+                &[triager()],
+                &caps,
+            )
+            .await;
+            let echo = &value["json"];
+
+            assert_eq!(echo["agent"], "triager");
+            assert_eq!(
+                echo["instructions"], "Be terse.\n\nPrefer `bug`.",
+                "node instructions append to the definition's"
+            );
+            assert_eq!(echo["model"], "opus", "the node overrides the model");
+            assert_eq!(
+                echo["provider"], "anthropic",
+                "an un-overridden provider survives from the definition"
+            );
+            assert_eq!(echo["working_dir"], "/srv/other");
+            assert_eq!(echo["prompt"], "Triage it.");
+            assert_eq!(echo["data"][0]["seed"], 1, "input items ride along structurally");
+            assert_eq!(echo["limits"]["max_steps"], 4, "the node tightened it");
+            assert_eq!(echo["limits"]["max_tool_calls"], 20, "un-narrowed bound survives");
+            assert_eq!(echo["limits"]["tool_timeout_secs"], 30);
+            assert_eq!(echo["limits"]["agent_timeout_secs"], 300);
+            assert_eq!(echo["metadata"]["tier"], "fast");
+            assert_eq!(echo["metadata"]["extra"], true);
+            assert_eq!(
+                echo["tools"],
+                json!(["github.search"]),
+                "the node narrowed the definition's two grants to one"
+            );
+            assert_eq!(echo["identity"]["node_id"], "n");
+            assert_eq!(echo["identity"]["run_id"], "run_7");
+            assert_eq!(echo["identity"]["depth"], 2);
+            assert_eq!(value["meta"]["stop"], "finished");
+            assert_eq!(value["meta"]["agent_ref"], "triager");
+            assert_eq!(value["meta"]["usage"]["steps"], 1);
+        }
+
+        #[tokio::test]
+        async fn the_in_graph_registry_wins_over_the_harnesss() {
+            let host_side = AgentDefinition {
+                id: "triager".into(),
+                model: Some("host-model".into()),
+                ..Default::default()
+            };
+            let caps = mock_capabilities_with_agent(MockAgentHarness::new().with(host_side));
+            let value =
+                run_with_registry(json!({ "agent_ref": "triager" }), &[triager()], &caps).await;
+            assert_eq!(value["json"]["model"], "sonnet", "the graph's definition wins");
+        }
+
+        #[tokio::test]
+        async fn the_harness_registry_answers_when_the_graph_does_not() {
+            let caps = mock_capabilities_with_agent(MockAgentHarness::new().with(triager()));
+            let value = run_with_registry(json!({ "agent_ref": "triager" }), &[], &caps).await;
+            assert_eq!(value["json"]["model"], "sonnet");
+            assert_eq!(value["json"]["provider"], "anthropic");
+        }
+
+        #[tokio::test]
+        async fn an_unknown_ref_passes_through_as_a_bare_id() {
+            // Not an error: the harness may resolve refs internally, which is
+            // exactly what it did before a registry existed.
+            let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+            let value = run_with_registry(json!({ "agent_ref": "mystery" }), &[], &caps).await;
+            assert_eq!(value["json"]["agent"], "mystery");
+            assert!(value["json"]["model"].is_null());
+        }
+
+        #[tokio::test]
+        async fn context_sources_resolve_in_declaration_order() {
+            let mut agent = triager();
+            agent.context = vec![
+                ContextSource::new(ContextSourceKind::Host {
+                    source: "soul".into(),
+                    params: json!({ "k": "v" }),
+                }),
+                ContextSource::new(ContextSourceKind::Memory {
+                    scope: "user".into(),
+                    query: "preferences".into(),
+                    limit: Some(3),
+                }),
+            ];
+            let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+            let value = run_with_registry(
+                json!({
+                    "agent_ref": "triager",
+                    "context": [
+                        { "kind": "text", "label": "Body", "text": "=item.seed" },
+                        { "kind": "items" }
+                    ]
+                }),
+                &[agent],
+                &caps,
+            )
+            .await;
+            let blocks = value["json"]["context"].as_array().expect("context blocks");
+
+            assert_eq!(blocks.len(), 4, "definition blocks first, then the node's");
+            assert_eq!(blocks[0]["kind"], "host");
+            assert_eq!(blocks[0]["data"]["k"], "v");
+            assert_eq!(blocks[1]["kind"], "memory");
+            assert_eq!(blocks[2]["label"], "Body");
+            assert_eq!(blocks[2]["text"], "1", "the =expression resolved against the item");
+            assert_eq!(blocks[3]["kind"], "items");
+            assert_eq!(blocks[3]["data"][0]["seed"], 1);
+            assert_eq!(blocks[3]["label"], "context_1", "unlabelled blocks get a positional label");
+        }
+
+        #[tokio::test]
+        async fn an_unresolvable_context_source_fails_the_node_unless_optional() {
+            let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+            let node = agent_node(json!({
+                "agent_ref": "triager",
+                "context": [{ "kind": "host", "source": "unknown" }]
+            }));
+            let input: Vec<Item> = vec![];
+            let run_meta = Value::Null;
+            let err = super::super::AgentNode
+                .execute(NodeContext {
+                    node: &node,
+                    input: &input,
+                    run: &run_meta,
+                    nodes: &Value::Null,
+                    caps: &caps,
+                    agents: &[],
+                    observer: &crate::observability::NoopObserver,
+                    token: crate::engine::CancellationToken::new(),
+                })
+                .await
+                .expect_err("an unresolved required block must fail the node");
+            let message = err.to_string();
+            assert!(message.contains("could not be resolved"), "{message}");
+            assert!(message.contains("optional"), "{message}");
+
+            // ...and marking it optional makes it survivable.
+            let value = run_with_registry(
+                json!({
+                    "agent_ref": "triager",
+                    "context": [{ "kind": "host", "source": "unknown", "optional": true }]
+                }),
+                &[],
+                &caps,
+            )
+            .await;
+            assert_eq!(value["json"]["context"], json!([]));
+        }
+
+        #[tokio::test]
+        async fn tool_grants_are_expanded_by_the_harness() {
+            let mut agent = triager();
+            agent.tools = vec![ToolGrant::new("github.*")];
+            let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+            let value = run_with_registry(json!({ "agent_ref": "triager" }), &[agent], &caps).await;
+            assert_eq!(
+                value["json"]["tools"],
+                json!(["github.alpha", "github.beta"]),
+                "the harness expanded the namespace pattern"
+            );
+        }
+
+        #[tokio::test]
+        async fn a_limit_stop_is_visible_and_skips_the_output_parser() {
+            let caps = mock_capabilities_with_agent(MockLimitedAgentRunner);
+            let value = run_with_registry(
+                json!({
+                    "agent_ref": "triager",
+                    // A schema the partial payload could never satisfy: if the
+                    // parser ran, this would fail the node instead of emitting.
+                    "output_parser": {
+                        "schema": { "type": "object", "required": ["definitely_absent"] },
+                        "auto_fix": false
+                    }
+                }),
+                &[],
+                &caps,
+            )
+            .await;
+            assert_eq!(value["meta"]["stop"], "limit_stop");
+            assert_eq!(value["meta"]["limit"], "max_steps");
+            assert_eq!(value["json"]["partial"], true, "the partial payload is kept");
+            assert_eq!(value["text"], "got as far as I could");
+        }
+
+        #[tokio::test]
+        async fn a_paused_agent_fails_loudly_rather_than_looking_finished() {
+            let caps = mock_capabilities_with_agent(MockPausingAgentRunner);
+            let node = agent_node(json!({ "agent_ref": "triager" }));
+            let input: Vec<Item> = vec![];
+            let run_meta = Value::Null;
+            let err = super::super::AgentNode
+                .execute(NodeContext {
+                    node: &node,
+                    input: &input,
+                    run: &run_meta,
+                    nodes: &Value::Null,
+                    caps: &caps,
+                    agents: &[],
+                    observer: &crate::observability::NoopObserver,
+                    token: crate::engine::CancellationToken::new(),
+                })
+                .await
+                .expect_err("a pause must not be reported as a finished answer");
+            let message = err.to_string();
+            assert!(message.contains("paused"), "{message}");
+            assert!(message.contains("tool_approval"), "{message}");
+        }
+
+        #[tokio::test]
+        async fn declared_context_still_resolves_without_a_harness() {
+            // No `AgentRunner` wired: the node degrades to a completion, but the
+            // author's declared context must not be silently dropped.
+            let node = agent_node(json!({
+                "prompt": "hi",
+                "context": [{ "kind": "memory", "scope": "user", "query": "prefs" }]
+            }));
+            let value = run_agent(&node, &crate::caps::mock::mock_capabilities()).await;
+            let blocks = &value["json"]["completion"]["context"];
+            assert_eq!(blocks[0]["source_kind"], "memory");
+            assert!(
+                blocks[0]["data"].get("results").is_some(),
+                "the memory capability resolved the block: {blocks}"
+            );
+        }
+
+        #[tokio::test]
+        async fn a_legacy_host_receives_the_byte_identical_config_it_always_did() {
+            // THE non-breaking guarantee, end to end: `MockAgentRunner`
+            // implements only `run_agent`, so the default `run` shim applies and
+            // the host sees exactly the (agent_ref, resolved config, conn) it
+            // received before the typed seam existed.
+            let caps =
+                mock_capabilities_with_agent(crate::caps::mock::MockAgentRunner);
+            let config = json!({
+                "agent_ref": "researcher",
+                "prompt": "hi",
+                "connection_ref": "acct_9"
+            });
+            let value = run_agent(&agent_node(config.clone()), &caps).await;
+            assert_eq!(value["raw"]["agent"], "researcher");
+            assert_eq!(value["raw"]["request"], config);
+            assert_eq!(value["raw"]["connection"], "acct_9");
+            assert_eq!(value["meta"]["stop"], "finished");
+        }
+
+        #[tokio::test]
+        async fn list_agents_exposes_the_harness_catalogue() {
+            let harness = MockAgentHarness::new().with(triager());
+            assert_eq!(harness.list_agents().await.unwrap().len(), 1);
+        }
+    }
 }

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -220,6 +220,86 @@ async fn run_turn_indexed(
     Ok(Item::new(super::envelope::from_parts(json, text, raw)))
 }
 
+/// Turns a harness's [`AgentRunOutcome`] into the emitted [`Item`]: honor the
+/// stop reason, apply the output-parser sub-port, and publish the envelope.
+///
+/// The stop reason is read **before** the payload, which is the point of having
+/// one. A bare value cannot distinguish an agent that answered from one that ran
+/// out of budget one step short, and the workflow marches downstream with a
+/// partial answer either way.
+async fn finish_agent_run(
+    ctx: &NodeContext<'_>,
+    cfg: &Value,
+    conn: Option<&str>,
+    agent_ref: &str,
+    outcome: crate::caps::AgentRunOutcome,
+) -> Result<Item> {
+    use crate::caps::StopReason;
+
+    let mut meta = serde_json::json!({ "stop": outcome.stop.as_str(), "agent_ref": agent_ref });
+
+    match &outcome.stop {
+        StopReason::Finished => {}
+        StopReason::LimitStop { limit } => {
+            tracing::warn!(
+                node = %ctx.node.id,
+                agent_ref,
+                limit = %limit,
+                "agent node: the agent stopped on a limit; its output is partial"
+            );
+            meta["limit"] = Value::from(limit.clone());
+        }
+        StopReason::Paused { reason, .. } => {
+            // A pause is resumable, not finished — and the engine cannot yet
+            // route one into its checkpoint/resume machinery. Failing loudly
+            // beats emitting a half-run agent's output as if it were an answer;
+            // see `StopReason::Paused`.
+            return Err(crate::error::EngineError::Capability(format!(
+                "agent node {}: agent `{agent_ref}` paused ({reason}); resuming a paused agent \
+                 is not supported yet, so the run cannot continue",
+                ctx.node.id
+            )));
+        }
+    }
+
+    if let Some(usage) = outcome.usage {
+        meta["usage"] = serde_json::to_value(usage).unwrap_or(Value::Null);
+    }
+
+    // Output-parser sub-port. Deliberately skipped on a limit stop: validating
+    // a knowingly partial payload against the author's schema either fails for
+    // the wrong reason or, with `auto_fix`, spends a model call inventing the
+    // missing half.
+    let mut value = outcome.json;
+    if matches!(outcome.stop, StopReason::Finished)
+        && let Some(parser) = cfg.get("output_parser").filter(|p| !p.is_null())
+        && let Some(parser_schema) = parser.get("schema").filter(|s| !s.is_null())
+    {
+        let auto_fix = parser
+            .get("auto_fix")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        let parser_conn = parser
+            .get("connection_ref")
+            .and_then(Value::as_str)
+            .or(conn);
+        value =
+            schema::parse_and_validate(value, parser_schema, auto_fix, &ctx.caps.llm, parser_conn)
+                .await?;
+    }
+
+    let json = match value {
+        Value::Object(_) | Value::Array(_) => value,
+        _ => Value::Null,
+    };
+    Ok(Item::new(super::envelope::from_parts_with_meta(
+        json,
+        outcome.text,
+        outcome.raw,
+        meta,
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::caps::mock::mock_capabilities;

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -131,7 +131,30 @@ async fn run_turn_indexed(
     // config *is* the completion request, exactly as it has always been — when
     // a `tools` sub-port is configured its descriptors ride along so the model
     // can elect to call one.
-    let response = ctx.caps.llm.complete(cfg.clone(), conn).await?;
+    //
+    // The one addition: when the author declared `context`, its sources are
+    // resolved and the key is replaced with the resulting blocks, so declared
+    // context still reaches the model on a host with no `AgentRunner`. Nodes
+    // that declare no context are untouched, so an existing graph's request is
+    // byte-identical to what it has always been.
+    let request = match cfg.get("context") {
+        Some(raw) if !raw.is_null() => {
+            let sources: Vec<crate::model::ContextSource> = serde_json::from_value(raw.clone())
+                .map_err(|e| {
+                    crate::error::EngineError::Capability(format!(
+                        "agent node {}: invalid `context`: {e}",
+                        ctx.node.id
+                    ))
+                })?;
+            let identity = super::agent_request::identity_of(ctx, item_index);
+            let blocks = super::agent_request::resolve_context(ctx, &sources, &identity).await?;
+            let mut request = cfg.clone();
+            request["context"] = serde_json::to_value(blocks).unwrap_or(Value::Null);
+            request
+        }
+        _ => cfg.clone(),
+    };
+    let response = ctx.caps.llm.complete(request, conn).await?;
 
     // `text`/`raw` are derived from the untouched completion; `value` is the
     // structured payload we thread the sub-ports (tool hop, output parser)

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -296,6 +296,7 @@ mod tests {
                 run: &run_meta,
                 nodes: &Value::Null,
                 caps: &caps,
+                agents: &[],
                 observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             })
@@ -313,6 +314,7 @@ mod tests {
                 run: &run_meta,
                 nodes: &Value::Null,
                 caps: &caps,
+                agents: &[],
                 observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             })
@@ -336,6 +338,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -363,6 +366,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -382,6 +386,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -407,6 +412,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -598,6 +604,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -988,7 +988,11 @@ mod tests {
             assert_eq!(blocks[2]["text"], "1", "the =expression resolved against the item");
             assert_eq!(blocks[3]["kind"], "items");
             assert_eq!(blocks[3]["data"][0]["seed"], 1);
-            assert_eq!(blocks[3]["label"], "context_1", "unlabelled blocks get a positional label");
+            assert_eq!(
+                blocks[3]["label"], "context_3",
+                "an unlabelled block is numbered by its position in the ASSEMBLED list, \
+                 not within the node's own `context` array"
+            );
         }
 
         #[tokio::test]

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -814,7 +814,9 @@ mod tests {
         };
         use crate::caps::{AgentRunner, Capabilities};
         use crate::data::Item;
-        use crate::model::{AgentDefinition, AgentLimits, ContextSource, ContextSourceKind, ToolGrant};
+        use crate::model::{
+            AgentDefinition, AgentLimits, ContextSource, ContextSourceKind, ToolGrant,
+        };
         use crate::nodes::{NodeContext, NodeExecutor};
         use serde_json::{Value, json};
 
@@ -900,9 +902,15 @@ mod tests {
             );
             assert_eq!(echo["working_dir"], "/srv/other");
             assert_eq!(echo["prompt"], "Triage it.");
-            assert_eq!(echo["data"][0]["seed"], 1, "input items ride along structurally");
+            assert_eq!(
+                echo["data"][0]["seed"], 1,
+                "input items ride along structurally"
+            );
             assert_eq!(echo["limits"]["max_steps"], 4, "the node tightened it");
-            assert_eq!(echo["limits"]["max_tool_calls"], 20, "un-narrowed bound survives");
+            assert_eq!(
+                echo["limits"]["max_tool_calls"], 20,
+                "un-narrowed bound survives"
+            );
             assert_eq!(echo["limits"]["tool_timeout_secs"], 30);
             assert_eq!(echo["limits"]["agent_timeout_secs"], 300);
             assert_eq!(echo["metadata"]["tier"], "fast");
@@ -930,7 +938,10 @@ mod tests {
             let caps = mock_capabilities_with_agent(MockAgentHarness::new().with(host_side));
             let value =
                 run_with_registry(json!({ "agent_ref": "triager" }), &[triager()], &caps).await;
-            assert_eq!(value["json"]["model"], "sonnet", "the graph's definition wins");
+            assert_eq!(
+                value["json"]["model"], "sonnet",
+                "the graph's definition wins"
+            );
         }
 
         #[tokio::test]
@@ -985,7 +996,10 @@ mod tests {
             assert_eq!(blocks[0]["data"]["k"], "v");
             assert_eq!(blocks[1]["kind"], "memory");
             assert_eq!(blocks[2]["label"], "Body");
-            assert_eq!(blocks[2]["text"], "1", "the =expression resolved against the item");
+            assert_eq!(
+                blocks[2]["text"], "1",
+                "the =expression resolved against the item"
+            );
             assert_eq!(blocks[3]["kind"], "items");
             assert_eq!(blocks[3]["data"][0]["seed"], 1);
             assert_eq!(
@@ -1066,7 +1080,10 @@ mod tests {
             .await;
             assert_eq!(value["meta"]["stop"], "limit_stop");
             assert_eq!(value["meta"]["limit"], "max_steps");
-            assert_eq!(value["json"]["partial"], true, "the partial payload is kept");
+            assert_eq!(
+                value["json"]["partial"], true,
+                "the partial payload is kept"
+            );
             assert_eq!(value["text"], "got as far as I could");
         }
 
@@ -1117,8 +1134,7 @@ mod tests {
             // implements only `run_agent`, so the default `run` shim applies and
             // the host sees exactly the (agent_ref, resolved config, conn) it
             // received before the typed seam existed.
-            let caps =
-                mock_capabilities_with_agent(crate::caps::mock::MockAgentRunner);
+            let caps = mock_capabilities_with_agent(crate::caps::mock::MockAgentRunner);
             let config = json!({
                 "agent_ref": "researcher",
                 "prompt": "hi",

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -442,6 +442,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/integration/agent_request.rs
+++ b/src/nodes/integration/agent_request.rs
@@ -125,6 +125,9 @@ pub(crate) fn merge_node_overrides(
     if let Some(provider) = cfg.get("provider").and_then(Value::as_str) {
         definition.provider = Some(provider.to_string());
     }
+    if let Some(working_dir) = cfg.get("working_dir").and_then(Value::as_str) {
+        definition.working_dir = Some(working_dir.to_string());
+    }
 
     let node_context: Vec<ContextSource> = field(cfg, "context", node_id)?;
     definition.context.extend(node_context);

--- a/src/nodes/integration/agent_request.rs
+++ b/src/nodes/integration/agent_request.rs
@@ -385,7 +385,8 @@ mod tests {
             limits: AgentLimits {
                 max_steps: Some(8),
                 max_tool_calls: Some(20),
-                max_seconds: None,
+                agent_timeout_secs: None,
+                tool_timeout_secs: Some(60),
             },
             tools: vec![
                 ToolGrant::new("github.search"),

--- a/src/nodes/integration/agent_request.rs
+++ b/src/nodes/integration/agent_request.rs
@@ -160,7 +160,10 @@ pub(crate) fn merge_node_overrides(
 /// a different credential.
 fn narrow_tools(granted: &[ToolGrant], requested: &[ToolGrant], node_id: &str) -> Vec<ToolGrant> {
     for want in requested {
-        if !granted.iter().any(|g| g.covers(&want.slug) || want.covers(&g.slug)) {
+        if !granted
+            .iter()
+            .any(|g| g.covers(&want.slug) || want.covers(&g.slug))
+        {
             tracing::warn!(
                 node = node_id,
                 slug = %want.slug,
@@ -170,7 +173,11 @@ fn narrow_tools(granted: &[ToolGrant], requested: &[ToolGrant], node_id: &str) -
     }
     granted
         .iter()
-        .filter(|g| requested.iter().any(|w| w.covers(&g.slug) || g.covers(&w.slug)))
+        .filter(|g| {
+            requested
+                .iter()
+                .any(|w| w.covers(&g.slug) || g.covers(&w.slug))
+        })
         .cloned()
         .collect()
 }
@@ -319,9 +326,8 @@ pub(crate) async fn assemble(
     // resolved value that happens to start with `=` would otherwise be
     // re-evaluated.
     let definition: AgentDefinition = {
-        let raw = serde_json::to_value(&definition).map_err(|e| {
-            EngineError::Capability(format!("agent node {}: {e}", ctx.node.id))
-        })?;
+        let raw = serde_json::to_value(&definition)
+            .map_err(|e| EngineError::Capability(format!("agent node {}: {e}", ctx.node.id)))?;
         let resolved = crate::expr::resolve_traced(&raw, scope).0;
         serde_json::from_value(resolved).map_err(|e| {
             EngineError::Capability(format!(
@@ -419,7 +425,10 @@ mod tests {
     #[test]
     fn node_instructions_append_rather_than_replace() {
         let agent = merged(json!({ "instructions": "Prefer `bug`." }));
-        assert_eq!(agent.instructions.as_deref(), Some("Be terse.\n\nPrefer `bug`."));
+        assert_eq!(
+            agent.instructions.as_deref(),
+            Some("Be terse.\n\nPrefer `bug`.")
+        );
     }
 
     #[test]
@@ -446,7 +455,11 @@ mod tests {
             { "slug": "shell.exec" }
         ] }));
         assert_eq!(
-            agent.tools.iter().map(|t| t.slug.as_str()).collect::<Vec<_>>(),
+            agent
+                .tools
+                .iter()
+                .map(|t| t.slug.as_str())
+                .collect::<Vec<_>>(),
             ["github.search"]
         );
     }

--- a/src/nodes/integration/agent_request.rs
+++ b/src/nodes/integration/agent_request.rs
@@ -203,7 +203,16 @@ pub(crate) async fn resolve_context(
         let kind = source.kind.as_str();
 
         let resolved: Option<ContextBlock> = match &source.kind {
-            ContextSourceKind::Text { text } => Some(ContextBlock::text(&label, kind, text)),
+            ContextSourceKind::Text { text } => Some(match text {
+                Value::String(s) => ContextBlock::text(&label, kind, s),
+                Value::Null => ContextBlock::text(&label, kind, ""),
+                other => ContextBlock {
+                    label: label.clone(),
+                    source_kind: kind.to_string(),
+                    text: Some(other.to_string()),
+                    data: other.clone(),
+                },
+            }),
             ContextSourceKind::Items => Some(ContextBlock::data(
                 &label,
                 kind,

--- a/src/nodes/integration/agent_request.rs
+++ b/src/nodes/integration/agent_request.rs
@@ -95,7 +95,7 @@ pub(crate) async fn resolve_definition(
 /// | field | rule |
 /// |---|---|
 /// | `instructions` | the node's are **appended** to the definition's, never replacing them — a node must not be able to silently neuter a curated agent's standing instructions |
-/// | `model`, `provider` | the node's win when set |
+/// | `model`, `provider`, `working_dir` | the node's win when set |
 /// | `context` | the definition's blocks first, then the node's |
 /// | `tools` | when the definition grants any, the node's list **intersects** them and may not add a tool the definition never granted; when the definition grants none there is nothing to narrow against, so the node's stand |
 /// | `limits` | field-wise, keeping the **lower** of each declared bound |
@@ -354,6 +354,7 @@ pub(crate) async fn assemble(
         context,
         tools,
         connection_ref: conn.map(str::to_string),
+        working_dir: agent.working_dir.clone(),
         identity,
         metadata: agent.metadata.clone(),
         output_schema: cfg

--- a/src/nodes/integration/agent_request.rs
+++ b/src/nodes/integration/agent_request.rs
@@ -1,0 +1,515 @@
+//! Assembling an [`AgentRunRequest`] from an `agent` node's declarative config.
+//!
+//! This is the whole of tinyflows' contribution to running an agent: the
+//! model↔tool loop belongs to the harness, so the engine's job is to turn what
+//! the author *declared* into one inert, fully-resolved request.
+//!
+//! ```text
+//!   graph `agents` registry ──┐
+//!   AgentRunner::resolve_agent ┼─► definition ─► merge node overrides
+//!   pass-through {id}         ─┘                        │
+//!                                                       ▼
+//!                        context sources ─► ContextBlock[]  (engine + harness)
+//!                        tool grants     ─► ToolDescriptor[] (harness)
+//!                                                       │
+//!                                                       ▼
+//!                                              AgentRunRequest
+//! ```
+//!
+//! ## Narrowing, never widening
+//!
+//! A node may reference a curated agent type and tighten it — fewer tools,
+//! lower limits, extra instructions — but never loosen it. An author who could
+//! widen a definition from the node that uses it would make the definition
+//! worthless as a statement of what an agent is allowed to do. See
+//! [`merge_node_overrides`].
+
+use serde_json::{Map, Value};
+
+use crate::caps::{
+    AgentInput, AgentModelSelection, AgentRunIdentity, AgentRunRequest, ContextBlock,
+    ToolDescriptor,
+};
+use crate::error::{EngineError, Result};
+use crate::model::{AgentDefinition, AgentLimits, ContextSource, ContextSourceKind, ToolGrant};
+use crate::nodes::NodeContext;
+
+/// Reads a node config's `agent_ref`, ignoring an empty string.
+///
+/// Empty is treated as absent so `{"agent_ref": ""}` keeps falling back to a
+/// plain completion rather than asking the harness for an agent called `""`.
+pub(crate) fn agent_ref_of(cfg: &Value) -> Option<&str> {
+    cfg.get("agent_ref")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+
+/// Deserializes a node config key, reporting a bad shape as a capability error
+/// naming the node and the key rather than a bare serde message.
+fn field<T: serde::de::DeserializeOwned + Default>(
+    cfg: &Value,
+    key: &str,
+    node_id: &str,
+) -> Result<T> {
+    match cfg.get(key) {
+        None | Some(Value::Null) => Ok(T::default()),
+        Some(value) => serde_json::from_value(value.clone()).map_err(|e| {
+            EngineError::Capability(format!("agent node {node_id}: invalid `{key}`: {e}"))
+        }),
+    }
+}
+
+/// Resolves `agent_ref` to a definition: the graph's own registry first, then
+/// the harness's, then a bare pass-through.
+///
+/// The order is the portability contract. A workflow that carries its own
+/// definition behaves identically on every host, so an in-graph entry always
+/// wins. Only when the graph is silent does the harness's curated catalogue
+/// answer, and a ref neither knows is **not** an error — it becomes
+/// `AgentDefinition { id: agent_ref, .. }`, which is exactly what a harness that
+/// resolves refs internally expects (and what it received before the registry
+/// existed).
+pub(crate) async fn resolve_definition(
+    ctx: &NodeContext<'_>,
+    agent_ref: &str,
+) -> Result<AgentDefinition> {
+    if let Some(in_graph) = ctx.agents.iter().find(|a| a.id == agent_ref) {
+        tracing::debug!(agent_ref, "agent node: resolved from the graph registry");
+        return Ok(in_graph.clone());
+    }
+    if let Some(runner) = ctx.caps.agent.as_ref()
+        && let Some(from_host) = runner.resolve_agent(agent_ref).await?
+    {
+        tracing::debug!(agent_ref, "agent node: resolved from the host registry");
+        return Ok(from_host);
+    }
+    tracing::debug!(
+        agent_ref,
+        "agent node: no registry entry; passing the ref through to the harness"
+    );
+    Ok(AgentDefinition::new(agent_ref))
+}
+
+/// Applies a node's overrides to its agent definition, narrowing only.
+///
+/// | field | rule |
+/// |---|---|
+/// | `instructions` | the node's are **appended** to the definition's, never replacing them — a node must not be able to silently neuter a curated agent's standing instructions |
+/// | `model`, `provider` | the node's win when set |
+/// | `context` | the definition's blocks first, then the node's |
+/// | `tools` | when the definition grants any, the node's list **intersects** them and may not add a tool the definition never granted; when the definition grants none there is nothing to narrow against, so the node's stand |
+/// | `limits` | field-wise, keeping the **lower** of each declared bound |
+/// | `metadata` | shallow key merge, the node's winning per key |
+///
+/// A node tool that the definition never granted is dropped with a warning
+/// rather than failing the run: [`crate::validate`] already rejects that
+/// statically for an in-graph definition, so reaching here means the definition
+/// came from the harness and the graph could not have known.
+pub(crate) fn merge_node_overrides(
+    mut definition: AgentDefinition,
+    cfg: &Value,
+    node_id: &str,
+) -> Result<AgentDefinition> {
+    if let Some(extra) = cfg.get("instructions").and_then(Value::as_str)
+        && !extra.is_empty()
+    {
+        definition.instructions = Some(match definition.instructions {
+            Some(base) if !base.is_empty() => format!("{base}\n\n{extra}"),
+            _ => extra.to_string(),
+        });
+    }
+
+    if let Some(model) = cfg.get("model").and_then(Value::as_str) {
+        definition.model = Some(model.to_string());
+    }
+    if let Some(provider) = cfg.get("provider").and_then(Value::as_str) {
+        definition.provider = Some(provider.to_string());
+    }
+
+    let node_context: Vec<ContextSource> = field(cfg, "context", node_id)?;
+    definition.context.extend(node_context);
+
+    let node_tools: Vec<ToolGrant> = field(cfg, "tools", node_id)?;
+    if !node_tools.is_empty() {
+        definition.tools = if definition.tools.is_empty() {
+            node_tools
+        } else {
+            narrow_tools(&definition.tools, &node_tools, node_id)
+        };
+    }
+
+    let node_limits: AgentLimits = field(cfg, "limits", node_id)?;
+    definition.limits = definition.limits.narrowed_by(&node_limits);
+
+    let node_metadata: Map<String, Value> = field(cfg, "metadata", node_id)?;
+    definition.metadata.extend(node_metadata);
+
+    Ok(definition)
+}
+
+/// Intersects a node's tool list with its definition's grants.
+///
+/// A definition grant survives when the node names it — exactly, or through a
+/// pattern the node wrote (`"github.*"` keeps every `github.` grant). The
+/// definition's descriptor is what survives, so its trusted `connection_ref`
+/// wins over any the node supplied: the definition is the more reviewed
+/// artifact, and a per-node grant must not be able to repoint a curated tool at
+/// a different credential.
+fn narrow_tools(granted: &[ToolGrant], requested: &[ToolGrant], node_id: &str) -> Vec<ToolGrant> {
+    for want in requested {
+        if !granted.iter().any(|g| g.covers(&want.slug) || want.covers(&g.slug)) {
+            tracing::warn!(
+                node = node_id,
+                slug = %want.slug,
+                "agent node: tool is not granted by the agent definition; ignoring"
+            );
+        }
+    }
+    granted
+        .iter()
+        .filter(|g| requested.iter().any(|w| w.covers(&g.slug) || g.covers(&w.slug)))
+        .cloned()
+        .collect()
+}
+
+/// Resolves each declared [`ContextSource`] into a [`ContextBlock`], in
+/// declaration order.
+///
+/// The engine resolves four kinds itself and delegates the fifth:
+///
+/// - `text` — already expression-resolved by the node's config pass; wrapped.
+/// - `items` — the node's input items.
+/// - `memory` / `flavour` — the existing
+///   [`MemoryProvider`](crate::caps::MemoryProvider), so the memory `scope`
+///   contract keeps exactly one home.
+/// - `host` — [`AgentRunner::resolve_context`](crate::caps::AgentRunner::resolve_context).
+///
+/// A source that cannot be resolved — the capability is not wired, or the
+/// harness does not recognize it — **fails the node** unless the author set
+/// `optional: true`. Silently dropping context is the wrong default: an agent
+/// missing its identity text or its connected-integration list still answers,
+/// confidently and wrongly, and that failure passes a smoke test.
+pub(crate) async fn resolve_context(
+    ctx: &NodeContext<'_>,
+    sources: &[ContextSource],
+    identity: &AgentRunIdentity,
+) -> Result<Vec<ContextBlock>> {
+    let mut blocks = Vec::with_capacity(sources.len());
+    for (index, source) in sources.iter().enumerate() {
+        let label = source.label_or_index(index);
+        let kind = source.kind.as_str();
+
+        let resolved: Option<ContextBlock> = match &source.kind {
+            ContextSourceKind::Text { text } => Some(ContextBlock::text(&label, kind, text)),
+            ContextSourceKind::Items => Some(ContextBlock::data(
+                &label,
+                kind,
+                Value::Array(ctx.input.iter().map(|i| i.json.clone()).collect()),
+            )),
+            ContextSourceKind::Memory {
+                scope,
+                query,
+                limit,
+            } => match ctx.caps.memory.as_ref() {
+                Some(memory) => {
+                    let mut opts = Map::new();
+                    opts.insert("operation".to_string(), Value::from("recall"));
+                    if let Some(limit) = limit {
+                        opts.insert("limit".to_string(), Value::from(*limit));
+                    }
+                    let data = memory.recall(scope, query, Value::Object(opts)).await?;
+                    Some(ContextBlock::data(&label, kind, data))
+                }
+                None => None,
+            },
+            ContextSourceKind::Flavour { slug } => match ctx.caps.memory.as_ref() {
+                Some(memory) => Some(ContextBlock::data(
+                    &label,
+                    kind,
+                    memory.flavour(slug).await?,
+                )),
+                None => None,
+            },
+            ContextSourceKind::Host { source, params } => match ctx.caps.agent.as_ref() {
+                Some(runner) => runner.resolve_context(source, params, identity).await?,
+                None => None,
+            },
+        };
+
+        match resolved {
+            Some(block) => blocks.push(block),
+            None if source.optional => {
+                tracing::debug!(
+                    node = %identity.node_id,
+                    label = %label,
+                    kind,
+                    "agent node: optional context source did not resolve; skipping"
+                );
+            }
+            None => {
+                return Err(EngineError::Capability(format!(
+                    "agent node {}: context source `{label}` ({kind}) could not be resolved — \
+                     the host wired no capability for it, or does not recognize it; \
+                     set `\"optional\": true` on the source to make this survivable",
+                    identity.node_id
+                )));
+            }
+        }
+    }
+    Ok(blocks)
+}
+
+/// Builds the run identity from the run-state `run` slice.
+///
+/// Everything here is informational: the engine enforces none of it. It exists
+/// because a harness that cannot attribute an agent run to a workflow run cannot
+/// bill it, trace it, or cap it.
+pub(crate) fn identity_of(ctx: &NodeContext<'_>, item_index: Option<usize>) -> AgentRunIdentity {
+    AgentRunIdentity {
+        run_id: ctx
+            .run
+            .get("run_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        workflow_id: ctx
+            .run
+            .get("workflow_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        node_id: ctx.node.id.clone(),
+        depth: ctx
+            .run
+            .get("sub_workflow_depth")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32,
+        item_index,
+    }
+}
+
+/// Assembles the full request for one agent turn.
+///
+/// `cfg` is the node's already expression-resolved config; the definition's own
+/// `=`-expressions are resolved here, against the same scope, because a
+/// definition lives in the graph's `agents` registry and never passes through
+/// the node's config resolution.
+pub(crate) async fn assemble(
+    ctx: &NodeContext<'_>,
+    cfg: &Value,
+    agent_ref: &str,
+    scope: &Value,
+    item_index: Option<usize>,
+) -> Result<AgentRunRequest> {
+    let definition = resolve_definition(ctx, agent_ref).await?;
+
+    // Resolve the definition's `=`-expressions against the node's scope. Done on
+    // the definition alone, before merging, so node-side values (already
+    // resolved by the node's config pass) are never resolved a second time — a
+    // resolved value that happens to start with `=` would otherwise be
+    // re-evaluated.
+    let definition: AgentDefinition = {
+        let raw = serde_json::to_value(&definition).map_err(|e| {
+            EngineError::Capability(format!("agent node {}: {e}", ctx.node.id))
+        })?;
+        let resolved = crate::expr::resolve_traced(&raw, scope).0;
+        serde_json::from_value(resolved).map_err(|e| {
+            EngineError::Capability(format!(
+                "agent node {}: agent definition `{agent_ref}` did not survive expression \
+                 resolution: {e}",
+                ctx.node.id
+            ))
+        })?
+    };
+
+    let agent = merge_node_overrides(definition, cfg, &ctx.node.id)?;
+    let identity = identity_of(ctx, item_index);
+    let conn = cfg.get("connection_ref").and_then(Value::as_str);
+
+    let context = resolve_context(ctx, &agent.context, &identity).await?;
+
+    let tools = match ctx.caps.agent.as_ref() {
+        Some(runner) => runner.resolve_tools(&agent.tools, conn).await?,
+        None => agent
+            .tools
+            .iter()
+            .map(|g| ToolDescriptor::from_grant(g, conn))
+            .collect(),
+    };
+
+    Ok(AgentRunRequest {
+        model: AgentModelSelection {
+            model: agent.model.clone(),
+            provider: agent.provider.clone(),
+        },
+        input: AgentInput {
+            text: cfg
+                .get("prompt")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            data: ctx.input.iter().map(|i| i.json.clone()).collect(),
+        },
+        context,
+        tools,
+        connection_ref: conn.map(str::to_string),
+        identity,
+        metadata: agent.metadata.clone(),
+        output_schema: cfg
+            .get("output_parser")
+            .and_then(|p| p.get("schema"))
+            .filter(|s| !s.is_null())
+            .cloned(),
+        // Forwarded verbatim so the default `AgentRunner::run` can replay the
+        // exact `run_agent(agent_ref, config, conn)` call a host received before
+        // this seam existed. Also the escape hatch for any key the typed request
+        // does not model.
+        config: cfg.clone(),
+        agent,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn definition() -> AgentDefinition {
+        AgentDefinition {
+            id: "triager".into(),
+            instructions: Some("Be terse.".into()),
+            model: Some("sonnet".into()),
+            provider: Some("anthropic".into()),
+            limits: AgentLimits {
+                max_steps: Some(8),
+                max_tool_calls: Some(20),
+                max_seconds: None,
+            },
+            tools: vec![
+                ToolGrant::new("github.search"),
+                ToolGrant {
+                    slug: "github.label".into(),
+                    connection_ref: Some("conn_definition".into()),
+                },
+            ],
+            metadata: json!({ "tier": "fast", "sandbox": "none" })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ..Default::default()
+        }
+    }
+
+    fn merged(cfg: Value) -> AgentDefinition {
+        merge_node_overrides(definition(), &cfg, "n").expect("merge")
+    }
+
+    #[test]
+    fn node_instructions_append_rather_than_replace() {
+        let agent = merged(json!({ "instructions": "Prefer `bug`." }));
+        assert_eq!(agent.instructions.as_deref(), Some("Be terse.\n\nPrefer `bug`."));
+    }
+
+    #[test]
+    fn node_model_and_provider_override() {
+        let agent = merged(json!({ "model": "opus", "provider": "bedrock" }));
+        assert_eq!(agent.model.as_deref(), Some("opus"));
+        assert_eq!(agent.provider.as_deref(), Some("bedrock"));
+
+        // An absent override leaves the definition's choice alone.
+        let untouched = merged(json!({}));
+        assert_eq!(untouched.model.as_deref(), Some("sonnet"));
+        assert_eq!(untouched.provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn node_tools_narrow_and_cannot_widen() {
+        let agent = merged(json!({ "tools": [{ "slug": "github.search" }] }));
+        assert_eq!(agent.tools.len(), 1);
+        assert_eq!(agent.tools[0].slug, "github.search");
+
+        // A tool the definition never granted is dropped, not added.
+        let agent = merged(json!({ "tools": [
+            { "slug": "github.search" },
+            { "slug": "shell.exec" }
+        ] }));
+        assert_eq!(
+            agent.tools.iter().map(|t| t.slug.as_str()).collect::<Vec<_>>(),
+            ["github.search"]
+        );
+    }
+
+    #[test]
+    fn the_definitions_tool_connection_wins_over_the_nodes() {
+        let agent = merged(json!({ "tools": [
+            { "slug": "github.label", "connection_ref": "conn_attacker" }
+        ] }));
+        assert_eq!(
+            agent.tools[0].connection_ref.as_deref(),
+            Some("conn_definition"),
+            "a node grant must not repoint a curated tool at another credential"
+        );
+    }
+
+    #[test]
+    fn a_node_pattern_narrows_to_the_matching_grants() {
+        let agent = merged(json!({ "tools": [{ "slug": "github.*" }] }));
+        assert_eq!(agent.tools.len(), 2, "the pattern keeps both github grants");
+    }
+
+    #[test]
+    fn a_definition_granting_nothing_leaves_node_tools_alone() {
+        // Nothing to narrow against, so the node's list stands — this is what
+        // keeps a plain `agent` node with a `tools` list working unchanged.
+        let bare = AgentDefinition::new("anon");
+        let agent =
+            merge_node_overrides(bare, &json!({ "tools": [{ "slug": "anything" }] }), "n").unwrap();
+        assert_eq!(agent.tools.len(), 1);
+    }
+
+    #[test]
+    fn node_limits_only_tighten() {
+        let agent = merged(json!({ "limits": { "max_steps": 4, "max_tool_calls": 999 } }));
+        assert_eq!(agent.limits.max_steps, Some(4));
+        assert_eq!(agent.limits.max_tool_calls, Some(20), "widening is ignored");
+    }
+
+    #[test]
+    fn node_metadata_merges_per_key() {
+        let agent = merged(json!({ "metadata": { "tier": "slow", "extra": true } }));
+        assert_eq!(agent.metadata.get("tier"), Some(&json!("slow")));
+        assert_eq!(agent.metadata.get("sandbox"), Some(&json!("none")));
+        assert_eq!(agent.metadata.get("extra"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn node_context_appends_after_the_definitions() {
+        let mut with_context = definition();
+        with_context.context = vec![ContextSource::new(ContextSourceKind::Text {
+            text: "standing".into(),
+        })];
+        let agent = merge_node_overrides(
+            with_context,
+            &json!({ "context": [{ "kind": "items" }] }),
+            "n",
+        )
+        .unwrap();
+        assert_eq!(agent.context.len(), 2);
+        assert_eq!(agent.context[0].kind.as_str(), "text");
+        assert_eq!(agent.context[1].kind.as_str(), "items");
+    }
+
+    #[test]
+    fn a_malformed_config_key_names_the_node_and_the_key() {
+        let err = merge_node_overrides(definition(), &json!({ "limits": "loads" }), "triage")
+            .expect_err("should reject");
+        let message = err.to_string();
+        assert!(message.contains("triage"), "{message}");
+        assert!(message.contains("limits"), "{message}");
+    }
+
+    #[test]
+    fn an_empty_agent_ref_reads_as_absent() {
+        assert_eq!(agent_ref_of(&json!({ "agent_ref": "" })), None);
+        assert_eq!(agent_ref_of(&json!({})), None);
+        assert_eq!(agent_ref_of(&json!({ "agent_ref": "x" })), Some("x"));
+    }
+}

--- a/src/nodes/integration/code.rs
+++ b/src/nodes/integration/code.rs
@@ -109,6 +109,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/integration/envelope.rs
+++ b/src/nodes/integration/envelope.rs
@@ -52,6 +52,24 @@ pub(crate) fn from_parts(json: Value, text: Option<String>, raw: Value) -> Value
     json!({ "json": json, "text": text, "raw": raw })
 }
 
+/// Like [`from_parts`], plus a `meta` key carrying per-node execution facts the
+/// payload itself cannot express.
+///
+/// Used by the `agent` node to publish *how* a run ended — `meta.stop` is
+/// `"finished"`, `"limit_stop"`, or `"paused"` — so a downstream `condition` can
+/// branch on whether the agent actually reached an answer rather than assuming
+/// it did. Purely additive: `json` / `text` / `raw` are byte-identical to
+/// [`from_parts`], so every existing `=item.json.…` binding is unaffected.
+#[must_use]
+pub(crate) fn from_parts_with_meta(
+    json: Value,
+    text: Option<String>,
+    raw: Value,
+    meta: Value,
+) -> Value {
+    json!({ "json": json, "text": text, "raw": raw, "meta": meta })
+}
+
 /// Wraps a capability's return `value` in the stable envelope, deriving `json`
 /// and `text` from it. Used by the pure capability nodes (`tool_call`,
 /// `http_request`, `code`) whose structured payload *is* the raw return.

--- a/src/nodes/integration/http_request.rs
+++ b/src/nodes/integration/http_request.rs
@@ -144,6 +144,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -182,6 +183,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -211,6 +213,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/integration/memory.rs
+++ b/src/nodes/integration/memory.rs
@@ -409,6 +409,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -465,6 +466,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -485,6 +487,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -512,6 +515,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -556,6 +560,7 @@ mod tests {
                 run: &run_meta,
                 nodes: &Value::Null,
                 caps: &caps,
+                agents: &[],
                 observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             };
@@ -582,6 +587,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -608,6 +614,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -638,6 +645,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/integration/mod.rs
+++ b/src/nodes/integration/mod.rs
@@ -5,6 +5,7 @@
 //! One module per node kind so parallel work can edit them without conflicts.
 
 pub mod agent;
+pub(crate) mod agent_request;
 pub mod code;
 pub(crate) mod envelope;
 pub mod http_request;

--- a/src/nodes/integration/output_parser.rs
+++ b/src/nodes/integration/output_parser.rs
@@ -82,6 +82,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -111,6 +112,7 @@ mod tests {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -167,6 +169,7 @@ mod tests {
         node: &Node,
         input: Vec<Item>,
         caps: &crate::caps::Capabilities,
+        agents: &[],
     ) -> Result<Vec<Item>> {
         let run_meta = Value::Null;
         let ctx = NodeContext {

--- a/src/nodes/integration/output_parser.rs
+++ b/src/nodes/integration/output_parser.rs
@@ -177,6 +177,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/integration/output_parser.rs
+++ b/src/nodes/integration/output_parser.rs
@@ -169,7 +169,6 @@ mod tests {
         node: &Node,
         input: Vec<Item>,
         caps: &crate::caps::Capabilities,
-        agents: &[],
     ) -> Result<Vec<Item>> {
         let run_meta = Value::Null;
         let ctx = NodeContext {

--- a/src/nodes/integration/shell_tests.rs
+++ b/src/nodes/integration/shell_tests.rs
@@ -36,6 +36,7 @@ async fn execute_with(caps: Capabilities, config: Value) -> Result<NodeOutput> {
             run: &Value::Null,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         })

--- a/src/nodes/integration/sub_workflow.rs
+++ b/src/nodes/integration/sub_workflow.rs
@@ -420,6 +420,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -434,6 +435,7 @@ mod tests {
         config: Value,
         input_items: Vec<crate::data::Item>,
         caps: &Capabilities,
+        agents: &[],
     ) -> NodeOutput {
         let mut sw = node("sw", NodeKind::SubWorkflow);
         sw.config = config;
@@ -699,6 +701,7 @@ mod tests {
         config: Value,
         run_meta: Value,
         caps: &Capabilities,
+        agents: &[],
     ) -> Result<NodeOutput, EngineError> {
         let mut sw = node("sw", NodeKind::SubWorkflow);
         sw.config = config;
@@ -1043,6 +1046,7 @@ mod cancellation_propagation_tests {
     async fn run_cancelling_on_slow(
         graph: &WorkflowGraph,
         caps: &Capabilities,
+        agents: &[],
         token: CancellationToken,
         slow_started: Arc<Notify>,
     ) -> (RunOutcome, Duration) {

--- a/src/nodes/integration/sub_workflow.rs
+++ b/src/nodes/integration/sub_workflow.rs
@@ -445,6 +445,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -710,6 +711,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -1044,7 +1046,6 @@ mod cancellation_propagation_tests {
     async fn run_cancelling_on_slow(
         graph: &WorkflowGraph,
         caps: &Capabilities,
-        agents: &[],
         token: CancellationToken,
         slow_started: Arc<Notify>,
     ) -> (RunOutcome, Duration) {

--- a/src/nodes/integration/sub_workflow.rs
+++ b/src/nodes/integration/sub_workflow.rs
@@ -435,7 +435,6 @@ mod tests {
         config: Value,
         input_items: Vec<crate::data::Item>,
         caps: &Capabilities,
-        agents: &[],
     ) -> NodeOutput {
         let mut sw = node("sw", NodeKind::SubWorkflow);
         sw.config = config;
@@ -701,7 +700,6 @@ mod tests {
         config: Value,
         run_meta: Value,
         caps: &Capabilities,
-        agents: &[],
     ) -> Result<NodeOutput, EngineError> {
         let mut sw = node("sw", NodeKind::SubWorkflow);
         sw.config = config;

--- a/src/nodes/integration/tool_call.rs
+++ b/src/nodes/integration/tool_call.rs
@@ -179,6 +179,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -206,6 +207,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -232,6 +234,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -254,6 +257,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -282,6 +286,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -311,6 +316,7 @@ mod tests {
             run: &run_meta,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -452,6 +452,7 @@ mod tests {
                     run: &run,
                     nodes: &Value::Null,
                     caps: &caps,
+                    agents: &[],
                     observer: &crate::observability::NoopObserver,
                     token: crate::engine::CancellationToken::new(),
                 })
@@ -477,6 +478,7 @@ mod tests {
                 run: &run,
                 nodes: &Value::Null,
                 caps: &caps,
+                agents: &[],
                 observer: &crate::observability::NoopObserver,
                 token: crate::engine::CancellationToken::new(),
             })
@@ -507,6 +509,7 @@ mod tests {
             run: &run,
             nodes: &nodes_state,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };
@@ -538,6 +541,7 @@ mod tests {
             run: &run,
             nodes: &Value::Null,
             caps: &caps,
+            agents: &[],
             observer: &crate::observability::NoopObserver,
             token: crate::engine::CancellationToken::new(),
         };

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -39,6 +39,16 @@ pub struct NodeContext<'a> {
     pub nodes: &'a Value,
     /// Host-provided capabilities.
     pub caps: &'a Capabilities,
+    /// The graph's own agent registry
+    /// ([`WorkflowGraph::agents`](crate::model::WorkflowGraph::agents)).
+    ///
+    /// An `agent` node resolves its `agent_ref` here first, before falling back
+    /// to the harness's registry via
+    /// [`AgentRunner::resolve_agent`](crate::caps::AgentRunner::resolve_agent),
+    /// so a workflow carrying its own definitions behaves identically on every
+    /// host. Empty for a graph that declares none. Every other node kind ignores
+    /// it.
+    pub agents: &'a [crate::model::AgentDefinition],
     /// Host observer used to report per-item fan-out progress.
     pub observer: &'a dyn crate::observability::RunObserver,
     /// The run's cooperative-cancellation token (see

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2510,7 +2510,7 @@ mod loop_tests {
                 "limits": { "max_steps": 8, "tool_timeout_secs": 30 }
             }))
             .unwrap();
-            let graph = graph(
+            let graph = agent_graph(
                 vec![agent],
                 json!({
                     "agent_ref": "triager",
@@ -2524,7 +2524,7 @@ mod loop_tests {
 
         #[test]
         fn duplicate_agent_ids_are_rejected() {
-            let graph = graph(
+            let graph = agent_graph(
                 vec![AgentDefinition::new("dup"), AgentDefinition::new("dup")],
                 json!({}),
             );
@@ -2558,7 +2558,7 @@ mod loop_tests {
             let by_slug = agent_graph(vec![], json!({ "tools": [{ "slug": "=item.tool" }] }));
             assert!(reasons(&by_slug).iter().any(|r| r.contains("`slug` must be a literal")));
 
-            let by_conn = graph(
+            let by_conn = agent_graph(
                 vec![],
                 json!({ "tools": [{ "slug": "ok", "connection_ref": "=item.acct" }] }),
             );
@@ -2587,7 +2587,7 @@ mod loop_tests {
         fn a_node_may_not_widen_its_agents_tool_grants() {
             let mut agent = AgentDefinition::new("triager");
             agent.tools = vec![crate::model::ToolGrant::new("github.search")];
-            let graph = graph(
+            let graph = agent_graph(
                 vec![agent],
                 json!({ "agent_ref": "triager", "tools": [{ "slug": "shell.exec" }] }),
             );
@@ -2602,7 +2602,7 @@ mod loop_tests {
 
         #[test]
         fn an_unknown_memory_scope_is_rejected() {
-            let graph = graph(
+            let graph = agent_graph(
                 vec![],
                 json!({ "context": [{ "kind": "memory", "scope": "=item.scope", "query": "q" }] }),
             );
@@ -2640,7 +2640,7 @@ mod loop_tests {
                 vec![("a".to_string(), "host_side".to_string())]
             );
 
-            let declared = graph(
+            let declared = agent_graph(
                 vec![AgentDefinition::new("host_side")],
                 json!({ "agent_ref": "host_side" }),
             );

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2640,8 +2640,11 @@ mod loop_tests {
                 vec![("a".to_string(), "host_side".to_string())]
             );
 
-            let known = graph(vec![AgentDefinition::new("host_side")], json!({ "agent_ref": "host_side" }));
-            assert!(unresolved_agent_refs(&known).is_empty());
+            let declared = graph(
+                vec![AgentDefinition::new("host_side")],
+                json!({ "agent_ref": "host_side" }),
+            );
+            assert!(unresolved_agent_refs(&declared).is_empty());
         }
 
         #[test]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -572,17 +572,21 @@ fn validate_agents(graph: &WorkflowGraph, errors: &mut Vec<ValidationError>) {
                          (expected a literal user|flow|flows)"
                     ))
                 } else if query.is_empty() {
-                    Some(format!("context source `{label}` has an empty memory `query`"))
+                    Some(format!(
+                        "context source `{label}` has an empty memory `query`"
+                    ))
                 } else {
                     None
                 }
             }
-            ContextSourceKind::Flavour { slug } if slug.is_empty() => {
-                Some(format!("context source `{label}` has an empty flavour `slug`"))
-            }
+            ContextSourceKind::Flavour { slug } if slug.is_empty() => Some(format!(
+                "context source `{label}` has an empty flavour `slug`"
+            )),
             ContextSourceKind::Host { source: name, .. } => {
                 if name.is_empty() {
-                    Some(format!("context source `{label}` has an empty host `source`"))
+                    Some(format!(
+                        "context source `{label}` has an empty host `source`"
+                    ))
                 } else if is_expression(name) {
                     Some(format!(
                         "context source `{label}` host `source` must be a literal, not the \
@@ -608,8 +612,10 @@ fn validate_agents(graph: &WorkflowGraph, errors: &mut Vec<ValidationError>) {
         .into_iter()
         .find(|(_, v)| *v == Some(0));
         zero.map(|(field, _)| {
-            format!("`limits.{field}` must be greater than 0 (an agent that may take 0 steps \
-                     cannot run); omit it for no bound")
+            format!(
+                "`limits.{field}` must be greater than 0 (an agent that may take 0 steps \
+                     cannot run); omit it for no bound"
+            )
         })
     }
 
@@ -2496,7 +2502,10 @@ mod loop_tests {
         }
 
         fn reasons(graph: &WorkflowGraph) -> Vec<String> {
-            validate_all(graph).iter().map(ToString::to_string).collect()
+            validate_all(graph)
+                .iter()
+                .map(ToString::to_string)
+                .collect()
         }
 
         #[test]
@@ -2547,7 +2556,9 @@ mod loop_tests {
             // could include model output, and would choose the agent's tools.
             let graph = agent_graph(vec![], json!({ "agent_ref": "=item.which_agent" }));
             assert!(
-                reasons(&graph).iter().any(|r| r.contains("must be a literal")),
+                reasons(&graph)
+                    .iter()
+                    .any(|r| r.contains("must be a literal")),
                 "{:?}",
                 reasons(&graph)
             );
@@ -2556,7 +2567,11 @@ mod loop_tests {
         #[test]
         fn an_expression_tool_slug_or_connection_is_rejected() {
             let by_slug = agent_graph(vec![], json!({ "tools": [{ "slug": "=item.tool" }] }));
-            assert!(reasons(&by_slug).iter().any(|r| r.contains("`slug` must be a literal")));
+            assert!(
+                reasons(&by_slug)
+                    .iter()
+                    .any(|r| r.contains("`slug` must be a literal"))
+            );
 
             let by_conn = agent_graph(
                 vec![],
@@ -2607,7 +2622,9 @@ mod loop_tests {
                 json!({ "context": [{ "kind": "memory", "scope": "=item.scope", "query": "q" }] }),
             );
             assert!(
-                reasons(&graph).iter().any(|r| r.contains("unknown memory scope")),
+                reasons(&graph)
+                    .iter()
+                    .any(|r| r.contains("unknown memory scope")),
                 "{:?}",
                 reasons(&graph)
             );
@@ -2626,7 +2643,11 @@ mod loop_tests {
         #[test]
         fn a_malformed_context_or_limits_block_reports_the_key() {
             let graph = agent_graph(vec![], json!({ "context": "not an array" }));
-            assert!(reasons(&graph).iter().any(|r| r.contains("invalid `context`")));
+            assert!(
+                reasons(&graph)
+                    .iter()
+                    .any(|r| r.contains("invalid `context`"))
+            );
         }
 
         #[test]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2467,4 +2467,197 @@ mod loop_tests {
         };
         assert_eq!(validate_all(&graph), Vec::new());
     }
+
+    // ---- agent registry + agent-node configuration ------------------------
+
+    mod agents {
+        use super::{node, node_cfg};
+        use crate::error::ValidationError;
+        use crate::model::{AgentDefinition, NodeKind, WorkflowGraph};
+        use crate::validate::{unresolved_agent_refs, validate_all};
+        use serde_json::json;
+
+        /// A one-agent-node graph with the given registry and node config.
+        fn graph(agents: Vec<AgentDefinition>, config: serde_json::Value) -> WorkflowGraph {
+            WorkflowGraph {
+                agents,
+                nodes: vec![
+                    node("t", NodeKind::Trigger),
+                    node_cfg("a", NodeKind::Agent, config),
+                ],
+                edges: vec![crate::model::Edge {
+                    from_node: "t".into(),
+                    from_port: "main".into(),
+                    to_node: "a".into(),
+                    to_port: "main".into(),
+                }],
+                ..Default::default()
+            }
+        }
+
+        fn reasons(graph: &WorkflowGraph) -> Vec<String> {
+            validate_all(graph).iter().map(ToString::to_string).collect()
+        }
+
+        #[test]
+        fn a_well_formed_registry_and_node_validate_clean() {
+            let agent: AgentDefinition = serde_json::from_value(json!({
+                "id": "triager",
+                "model": "opus",
+                "provider": "anthropic",
+                "tools": [{ "slug": "github.*" }],
+                "context": [{ "kind": "memory", "scope": "user", "query": "prefs" }],
+                "limits": { "max_steps": 8, "tool_timeout_secs": 30 }
+            }))
+            .unwrap();
+            let graph = graph(
+                vec![agent],
+                json!({
+                    "agent_ref": "triager",
+                    "prompt": "go",
+                    "tools": [{ "slug": "github.search" }],
+                    "limits": { "max_steps": 4 }
+                }),
+            );
+            assert_eq!(validate_all(&graph), Vec::new());
+        }
+
+        #[test]
+        fn duplicate_agent_ids_are_rejected() {
+            let graph = graph(
+                vec![AgentDefinition::new("dup"), AgentDefinition::new("dup")],
+                json!({}),
+            );
+            assert!(
+                validate_all(&graph).contains(&ValidationError::DuplicateAgentId("dup".into())),
+                "{:?}",
+                validate_all(&graph)
+            );
+        }
+
+        #[test]
+        fn an_empty_agent_id_is_rejected() {
+            let graph = graph(vec![AgentDefinition::new("")], json!({}));
+            assert!(reasons(&graph).iter().any(|r| r.contains("non-empty `id`")));
+        }
+
+        #[test]
+        fn an_expression_agent_ref_is_rejected() {
+            // The escalation guard: an expression resolves from run data, which
+            // could include model output, and would choose the agent's tools.
+            let graph = graph(vec![], json!({ "agent_ref": "=item.which_agent" }));
+            assert!(
+                reasons(&graph).iter().any(|r| r.contains("must be a literal")),
+                "{:?}",
+                reasons(&graph)
+            );
+        }
+
+        #[test]
+        fn an_expression_tool_slug_or_connection_is_rejected() {
+            let by_slug = graph(vec![], json!({ "tools": [{ "slug": "=item.tool" }] }));
+            assert!(reasons(&by_slug).iter().any(|r| r.contains("`slug` must be a literal")));
+
+            let by_conn = graph(
+                vec![],
+                json!({ "tools": [{ "slug": "ok", "connection_ref": "=item.acct" }] }),
+            );
+            assert!(
+                reasons(&by_conn)
+                    .iter()
+                    .any(|r| r.contains("`connection_ref` must be a literal"))
+            );
+        }
+
+        #[test]
+        fn only_a_trailing_dot_star_is_a_valid_tool_pattern() {
+            for bad in ["*", "*.post", "sla*ck"] {
+                let g = graph(vec![], json!({ "tools": [{ "slug": bad }] }));
+                assert!(
+                    reasons(&g).iter().any(|r| r.contains("valid pattern")),
+                    "{bad:?} should be rejected: {:?}",
+                    reasons(&g)
+                );
+            }
+            let good = graph(vec![], json!({ "tools": [{ "slug": "slack.*" }] }));
+            assert_eq!(validate_all(&good), Vec::new());
+        }
+
+        #[test]
+        fn a_node_may_not_widen_its_agents_tool_grants() {
+            let mut agent = AgentDefinition::new("triager");
+            agent.tools = vec![crate::model::ToolGrant::new("github.search")];
+            let graph = graph(
+                vec![agent],
+                json!({ "agent_ref": "triager", "tools": [{ "slug": "shell.exec" }] }),
+            );
+            assert!(
+                reasons(&graph)
+                    .iter()
+                    .any(|r| r.contains("is not granted by agent")),
+                "{:?}",
+                reasons(&graph)
+            );
+        }
+
+        #[test]
+        fn an_unknown_memory_scope_is_rejected() {
+            let graph = graph(
+                vec![],
+                json!({ "context": [{ "kind": "memory", "scope": "=item.scope", "query": "q" }] }),
+            );
+            assert!(
+                reasons(&graph).iter().any(|r| r.contains("unknown memory scope")),
+                "{:?}",
+                reasons(&graph)
+            );
+        }
+
+        #[test]
+        fn a_zero_limit_is_rejected() {
+            let graph = graph(vec![], json!({ "limits": { "max_steps": 0 } }));
+            assert!(
+                reasons(&graph).iter().any(|r| r.contains("greater than 0")),
+                "{:?}",
+                reasons(&graph)
+            );
+        }
+
+        #[test]
+        fn a_malformed_context_or_limits_block_reports_the_key() {
+            let graph = graph(vec![], json!({ "context": "not an array" }));
+            assert!(reasons(&graph).iter().any(|r| r.contains("invalid `context`")));
+        }
+
+        #[test]
+        fn an_unresolved_agent_ref_is_deferred_not_an_error() {
+            // Validation runs without capabilities and the harness registry is
+            // the documented fallback, so this is valid — but reportable.
+            let graph = graph(vec![], json!({ "agent_ref": "host_side" }));
+            assert_eq!(validate_all(&graph), Vec::new());
+            assert_eq!(
+                unresolved_agent_refs(&graph),
+                vec![("a".to_string(), "host_side".to_string())]
+            );
+
+            let known = graph(vec![AgentDefinition::new("host_side")], json!({ "agent_ref": "host_side" }));
+            assert!(unresolved_agent_refs(&known).is_empty());
+        }
+
+        #[test]
+        fn the_new_error_variants_carry_stable_codes() {
+            assert_eq!(
+                ValidationError::DuplicateAgentId("x".into()).code(),
+                "duplicate_agent_id"
+            );
+            assert_eq!(
+                ValidationError::InvalidAgentDefinition {
+                    agent: "x".into(),
+                    reason: "y".into()
+                }
+                .code(),
+                "invalid_agent_definition"
+            );
+        }
+    }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2478,7 +2478,7 @@ mod loop_tests {
         use serde_json::json;
 
         /// A one-agent-node graph with the given registry and node config.
-        fn graph(agents: Vec<AgentDefinition>, config: serde_json::Value) -> WorkflowGraph {
+        fn agent_graph(agents: Vec<AgentDefinition>, config: serde_json::Value) -> WorkflowGraph {
             WorkflowGraph {
                 agents,
                 nodes: vec![
@@ -2537,7 +2537,7 @@ mod loop_tests {
 
         #[test]
         fn an_empty_agent_id_is_rejected() {
-            let graph = graph(vec![AgentDefinition::new("")], json!({}));
+            let graph = agent_graph(vec![AgentDefinition::new("")], json!({}));
             assert!(reasons(&graph).iter().any(|r| r.contains("non-empty `id`")));
         }
 
@@ -2545,7 +2545,7 @@ mod loop_tests {
         fn an_expression_agent_ref_is_rejected() {
             // The escalation guard: an expression resolves from run data, which
             // could include model output, and would choose the agent's tools.
-            let graph = graph(vec![], json!({ "agent_ref": "=item.which_agent" }));
+            let graph = agent_graph(vec![], json!({ "agent_ref": "=item.which_agent" }));
             assert!(
                 reasons(&graph).iter().any(|r| r.contains("must be a literal")),
                 "{:?}",
@@ -2555,7 +2555,7 @@ mod loop_tests {
 
         #[test]
         fn an_expression_tool_slug_or_connection_is_rejected() {
-            let by_slug = graph(vec![], json!({ "tools": [{ "slug": "=item.tool" }] }));
+            let by_slug = agent_graph(vec![], json!({ "tools": [{ "slug": "=item.tool" }] }));
             assert!(reasons(&by_slug).iter().any(|r| r.contains("`slug` must be a literal")));
 
             let by_conn = graph(
@@ -2572,14 +2572,14 @@ mod loop_tests {
         #[test]
         fn only_a_trailing_dot_star_is_a_valid_tool_pattern() {
             for bad in ["*", "*.post", "sla*ck"] {
-                let g = graph(vec![], json!({ "tools": [{ "slug": bad }] }));
+                let g = agent_graph(vec![], json!({ "tools": [{ "slug": bad }] }));
                 assert!(
                     reasons(&g).iter().any(|r| r.contains("valid pattern")),
                     "{bad:?} should be rejected: {:?}",
                     reasons(&g)
                 );
             }
-            let good = graph(vec![], json!({ "tools": [{ "slug": "slack.*" }] }));
+            let good = agent_graph(vec![], json!({ "tools": [{ "slug": "slack.*" }] }));
             assert_eq!(validate_all(&good), Vec::new());
         }
 
@@ -2615,7 +2615,7 @@ mod loop_tests {
 
         #[test]
         fn a_zero_limit_is_rejected() {
-            let graph = graph(vec![], json!({ "limits": { "max_steps": 0 } }));
+            let graph = agent_graph(vec![], json!({ "limits": { "max_steps": 0 } }));
             assert!(
                 reasons(&graph).iter().any(|r| r.contains("greater than 0")),
                 "{:?}",
@@ -2625,7 +2625,7 @@ mod loop_tests {
 
         #[test]
         fn a_malformed_context_or_limits_block_reports_the_key() {
-            let graph = graph(vec![], json!({ "context": "not an array" }));
+            let graph = agent_graph(vec![], json!({ "context": "not an array" }));
             assert!(reasons(&graph).iter().any(|r| r.contains("invalid `context`")));
         }
 
@@ -2633,7 +2633,7 @@ mod loop_tests {
         fn an_unresolved_agent_ref_is_deferred_not_an_error() {
             // Validation runs without capabilities and the harness registry is
             // the documented fallback, so this is valid — but reportable.
-            let graph = graph(vec![], json!({ "agent_ref": "host_side" }));
+            let graph = agent_graph(vec![], json!({ "agent_ref": "host_side" }));
             assert_eq!(validate_all(&graph), Vec::new());
             assert_eq!(
                 unresolved_agent_refs(&graph),

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -556,7 +556,9 @@ fn validate_agents(graph: &WorkflowGraph, errors: &mut Vec<ValidationError>) {
     fn context_source_problem(source: &ContextSource, index: usize) -> Option<String> {
         let label = source.label_or_index(index);
         match &source.kind {
-            ContextSourceKind::Text { text } if text.is_empty() => {
+            ContextSourceKind::Text { text }
+                if text.is_null() || text.as_str().is_some_and(str::is_empty) =>
+            {
                 Some(format!("context source `{label}` has empty `text`"))
             }
             ContextSourceKind::Memory { scope, query, .. } => {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -600,7 +600,8 @@ fn validate_agents(graph: &WorkflowGraph, errors: &mut Vec<ValidationError>) {
         let zero = [
             ("max_steps", limits.max_steps),
             ("max_tool_calls", limits.max_tool_calls),
-            ("max_seconds", limits.max_seconds),
+            ("agent_timeout_secs", limits.agent_timeout_secs),
+            ("tool_timeout_secs", limits.tool_timeout_secs),
         ]
         .into_iter()
         .find(|(_, v)| *v == Some(0));

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -453,7 +453,322 @@ pub fn validate_all(graph: &WorkflowGraph) -> Vec<ValidationError> {
         }
     }
 
+    validate_agents(graph, &mut errors);
+
     errors
+}
+
+/// The graph's agent registry and every `agent` node's agent configuration.
+///
+/// Two things are checked here that cannot be checked anywhere else:
+///
+/// - **Literal-only reference fields.** `agent_ref`, a tool `slug`, a tool
+///   `connection_ref`, and a memory context `scope` may not be
+///   `=`-expressions. An expression resolves from run data — which may include
+///   model output — so allowing one would let upstream data choose which
+///   credential a call acts as, which tool it reaches, or which agent type (and
+///   therefore which tool grants) a turn runs with. Rejecting them structurally,
+///   before a run starts, is what makes that unbypassable.
+/// - **Context node ancestry.** A `node` context source naming a node the agent
+///   cannot be reached from would resolve to nothing at run time, and the agent
+///   would reason over an empty block without any error. This is statically
+///   decidable, so it is caught here.
+///
+/// An `agent_ref` the graph's registry does not declare is deliberately **not**
+/// an error: validation runs without capabilities, and the harness's own
+/// registry is the documented fallback. Hosts that want author-time resolution
+/// call [`unresolved_agent_refs`].
+fn validate_agents(graph: &WorkflowGraph, errors: &mut Vec<ValidationError>) {
+    use crate::model::{AgentLimits, ContextSource, ContextSourceKind, ToolGrant};
+
+    /// Whether an authored string is an `=`-expression rather than a literal.
+    fn is_expression(value: &str) -> bool {
+        value.starts_with('=')
+    }
+
+    let mut seen_agents = HashSet::new();
+    for agent in &graph.agents {
+        if agent.id.is_empty() {
+            errors.push(ValidationError::InvalidAgentDefinition {
+                agent: String::new(),
+                reason: "agent definition requires a non-empty `id`".to_string(),
+            });
+        } else if !seen_agents.insert(agent.id.as_str()) {
+            errors.push(ValidationError::DuplicateAgentId(agent.id.clone()));
+        }
+
+        for grant in &agent.tools {
+            if let Some(reason) = tool_grant_problem(grant) {
+                errors.push(ValidationError::InvalidAgentDefinition {
+                    agent: agent.id.clone(),
+                    reason,
+                });
+            }
+        }
+        for (index, source) in agent.context.iter().enumerate() {
+            if let Some(reason) = context_source_problem(source, index) {
+                errors.push(ValidationError::InvalidAgentDefinition {
+                    agent: agent.id.clone(),
+                    reason,
+                });
+            }
+        }
+        if let Some(reason) = limits_problem(&agent.limits) {
+            errors.push(ValidationError::InvalidAgentDefinition {
+                agent: agent.id.clone(),
+                reason,
+            });
+        }
+    }
+
+    /// Why a tool grant is unacceptable, or `None`.
+    fn tool_grant_problem(grant: &ToolGrant) -> Option<String> {
+        if grant.slug.is_empty() {
+            return Some("tool grant requires a non-empty `slug`".to_string());
+        }
+        if is_expression(&grant.slug) {
+            return Some(format!(
+                "tool grant `slug` must be a literal, not the expression {:?} — a tool chosen \
+                 by run data is a tool chosen by whatever wrote that data",
+                grant.slug
+            ));
+        }
+        if grant.slug == "*" || (grant.slug.contains('*') && !grant.slug.ends_with(".*")) {
+            return Some(format!(
+                "tool grant slug {:?} is not a valid pattern — only a trailing `.*` on a \
+                 non-empty prefix is allowed (e.g. \"github.*\"); to use the harness's default \
+                 tools, omit `tools` entirely",
+                grant.slug
+            ));
+        }
+        match grant.connection_ref.as_deref() {
+            Some(conn) if is_expression(conn) => Some(format!(
+                "tool grant `connection_ref` must be a literal, not the expression {conn:?} — a \
+                 credential selected by run data is the prompt-injection shape this field exists \
+                 to prevent"
+            )),
+            _ => None,
+        }
+    }
+
+    /// Why a context source is unacceptable, ignoring graph-position checks
+    /// (which only apply to a node, not to a reusable definition).
+    fn context_source_problem(source: &ContextSource, index: usize) -> Option<String> {
+        let label = source.label_or_index(index);
+        match &source.kind {
+            ContextSourceKind::Text { text } if text.is_empty() => {
+                Some(format!("context source `{label}` has empty `text`"))
+            }
+            ContextSourceKind::Memory { scope, query, .. } => {
+                if !matches!(scope.as_str(), "user" | "flow" | "flows") {
+                    // Literal enum, for the same unbypassable reason the `memory`
+                    // node validates its scope this way: an `=`-expression is
+                    // never one of the three literals, so a run-time-resolved
+                    // scope can never reach the memory provider.
+                    Some(format!(
+                        "context source `{label}` has unknown memory scope {scope:?} \
+                         (expected a literal user|flow|flows)"
+                    ))
+                } else if query.is_empty() {
+                    Some(format!("context source `{label}` has an empty memory `query`"))
+                } else {
+                    None
+                }
+            }
+            ContextSourceKind::Flavour { slug } if slug.is_empty() => {
+                Some(format!("context source `{label}` has an empty flavour `slug`"))
+            }
+            ContextSourceKind::Host { source: name, .. } => {
+                if name.is_empty() {
+                    Some(format!("context source `{label}` has an empty host `source`"))
+                } else if is_expression(name) {
+                    Some(format!(
+                        "context source `{label}` host `source` must be a literal, not the \
+                         expression {name:?} — which corpus an agent reads from should not be \
+                         chosen by run data"
+                    ))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Why a limits block is unacceptable, or `None`.
+    fn limits_problem(limits: &AgentLimits) -> Option<String> {
+        let zero = [
+            ("max_steps", limits.max_steps),
+            ("max_tool_calls", limits.max_tool_calls),
+            ("max_seconds", limits.max_seconds),
+        ]
+        .into_iter()
+        .find(|(_, v)| *v == Some(0));
+        zero.map(|(field, _)| {
+            format!("`limits.{field}` must be greater than 0 (an agent that may take 0 steps \
+                     cannot run); omit it for no bound")
+        })
+    }
+
+    for node in &graph.nodes {
+        if node.kind != NodeKind::Agent {
+            continue;
+        }
+        let config = &node.config;
+
+        match config.get("agent_ref") {
+            Some(Value::String(agent_ref)) if is_expression(agent_ref) => {
+                errors.push(ValidationError::InvalidNodeConfig {
+                    node: node.id.clone(),
+                    reason: format!(
+                        "`agent_ref` must be a literal, not the expression {agent_ref:?} — an \
+                         expression resolves from run data, which would let upstream (possibly \
+                         model-influenced) data select a differently-privileged agent type"
+                    ),
+                });
+            }
+            Some(value) if !value.is_string() && !value.is_null() => {
+                errors.push(ValidationError::InvalidNodeConfig {
+                    node: node.id.clone(),
+                    reason: "`agent_ref` must be a string".to_string(),
+                });
+            }
+            _ => {}
+        }
+
+        // Tool grants. Parsed rather than hand-walked so an author gets the same
+        // shape errors the executor would raise, before a run starts.
+        match config.get("tools") {
+            Some(raw) if !raw.is_null() => {
+                match serde_json::from_value::<Vec<ToolGrant>>(raw.clone()) {
+                    Ok(grants) => {
+                        for grant in &grants {
+                            if let Some(reason) = tool_grant_problem(grant) {
+                                errors.push(ValidationError::InvalidNodeConfig {
+                                    node: node.id.clone(),
+                                    reason,
+                                });
+                            }
+                        }
+                        // A node may narrow its agent definition's grants, never
+                        // widen them. Only checkable when the definition is
+                        // in-graph; a harness-resolved one is dropped with a
+                        // warning at run time instead.
+                        if let Some(agent_ref) = config.get("agent_ref").and_then(Value::as_str)
+                            && let Some(definition) = graph.agent(agent_ref)
+                            && !definition.tools.is_empty()
+                        {
+                            for grant in &grants {
+                                if !definition
+                                    .tools
+                                    .iter()
+                                    .any(|g| g.covers(&grant.slug) || grant.covers(&g.slug))
+                                {
+                                    errors.push(ValidationError::InvalidNodeConfig {
+                                        node: node.id.clone(),
+                                        reason: format!(
+                                            "tool {:?} is not granted by agent {agent_ref:?} — a \
+                                             node may narrow its agent's tools, never widen them",
+                                            grant.slug
+                                        ),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => errors.push(ValidationError::InvalidNodeConfig {
+                        node: node.id.clone(),
+                        reason: format!("invalid `tools`: {e}"),
+                    }),
+                }
+            }
+            _ => {}
+        }
+
+        match config.get("context") {
+            Some(raw) if !raw.is_null() => {
+                match serde_json::from_value::<Vec<ContextSource>>(raw.clone()) {
+                    Ok(sources) => {
+                        for (index, source) in sources.iter().enumerate() {
+                            if let Some(reason) = context_source_problem(source, index) {
+                                errors.push(ValidationError::InvalidNodeConfig {
+                                    node: node.id.clone(),
+                                    reason,
+                                });
+                            }
+                        }
+                    }
+                    Err(e) => errors.push(ValidationError::InvalidNodeConfig {
+                        node: node.id.clone(),
+                        reason: format!("invalid `context`: {e}"),
+                    }),
+                }
+            }
+            _ => {}
+        }
+
+        match config.get("limits") {
+            Some(raw) if !raw.is_null() => match serde_json::from_value::<AgentLimits>(raw.clone())
+            {
+                Ok(limits) => {
+                    if let Some(reason) = limits_problem(&limits) {
+                        errors.push(ValidationError::InvalidNodeConfig {
+                            node: node.id.clone(),
+                            reason,
+                        });
+                    }
+                }
+                Err(e) => errors.push(ValidationError::InvalidNodeConfig {
+                    node: node.id.clone(),
+                    reason: format!("invalid `limits`: {e}"),
+                }),
+            },
+            _ => {}
+        }
+    }
+}
+
+/// Every (node id, `agent_ref`) pair the graph's own registry does not resolve.
+///
+/// [`validate_all`] deliberately does not treat these as errors: it runs without
+/// capabilities, and the harness's registry is the documented fallback — a graph
+/// naming a host-curated agent is valid, not broken. A host that *can* consult
+/// its registry at author time calls this and checks each ref against its own
+/// catalogue, turning "will fail at run time" into an editor warning.
+///
+/// ```
+/// use tinyflows::model::WorkflowGraph;
+/// use tinyflows::validate::unresolved_agent_refs;
+///
+/// let graph: WorkflowGraph = serde_json::from_str(
+///     r#"{
+///       "agents": [{"id": "known"}],
+///       "nodes": [
+///         {"id": "a", "kind": "agent", "name": "a", "config": {"agent_ref": "known"}},
+///         {"id": "b", "kind": "agent", "name": "b", "config": {"agent_ref": "host_side"}}
+///       ],
+///       "edges": []
+///     }"#,
+/// )
+/// .unwrap();
+///
+/// assert_eq!(
+///     unresolved_agent_refs(&graph),
+///     vec![("b".to_string(), "host_side".to_string())]
+/// );
+/// ```
+#[must_use]
+pub fn unresolved_agent_refs(graph: &WorkflowGraph) -> Vec<(crate::model::NodeId, String)> {
+    graph
+        .nodes
+        .iter()
+        .filter(|node| node.kind == NodeKind::Agent)
+        .filter_map(|node| {
+            let agent_ref = node.config.get("agent_ref").and_then(Value::as_str)?;
+            (!agent_ref.is_empty() && graph.agent(agent_ref).is_none())
+                .then(|| (node.id.clone(), agent_ref.to_string()))
+        })
+        .collect()
 }
 
 /// Loop and cycle legality.

--- a/tests/configurable_agents_e2e.rs
+++ b/tests/configurable_agents_e2e.rs
@@ -27,7 +27,7 @@ fn graph_json() -> Value {
             "id": "triager",
             "name": "Issue triager",
             "description": "Labels and routes inbound issues.",
-            "instructions": "You triage issues for =inputs.repo.",
+            "instructions": "You triage issues.",
             "model": "sonnet",
             "provider": "anthropic",
             "working_dir": "/srv/checkout",
@@ -87,8 +87,9 @@ async fn a_graph_declared_agent_reaches_the_harness_merged_and_narrowed() {
 
     assert_eq!(request["agent"], "triager");
     assert_eq!(
-        request["instructions"], "You triage issues for acme/api.\n\nPrefer `bug` when a stack trace is present.",
-        "the definition's instructions resolved their =expression and the node's appended"
+        request["instructions"],
+        "You triage issues.\n\nPrefer `bug` when a stack trace is present.",
+        "the node's instructions append to the definition's rather than replacing them"
     );
     assert_eq!(request["model"], "opus", "the node overrode the model");
     assert_eq!(request["provider"], "anthropic", "the definition's provider survived");
@@ -144,7 +145,9 @@ async fn a_legacy_harness_still_receives_the_raw_config() {
     // The non-breaking guarantee through the whole engine: `MockAgentRunner`
     // implements only `run_agent`, so the default `run` shim forwards the node's
     // resolved config exactly as it did before the typed seam existed.
-    let graph = parse(graph_json());
+    let mut json = graph_json();
+    json["agents"][0]["context"] = json!([]);
+    let graph = parse(json);
     let caps = mock_capabilities_with_agent(MockAgentRunner);
     let item = run_triage(&graph, &caps).await;
 
@@ -196,4 +199,38 @@ async fn the_registry_survives_a_json_round_trip() {
     assert_eq!(agent.working_dir.as_deref(), Some("/srv/checkout"));
     assert_eq!(agent.limits.tool_timeout_secs, Some(30));
     assert_eq!(agent.tools.len(), 2);
+}
+
+#[tokio::test]
+async fn a_host_context_source_a_harness_cannot_expand_fails_loudly() {
+    // `MockAgentRunner` implements only `run_agent`, so `resolve_context`
+    // defaults to `Ok(None)`. The author declared context that cannot be
+    // delivered, and the node must say so rather than run the agent on a
+    // silently smaller context — an agent missing its conventions still answers,
+    // confidently and wrongly.
+    let graph = parse(graph_json());
+    let compiled = compile(&graph).expect("compile");
+    let input = RunInput::new(Value::Null).with_inputs(
+        json!({ "repo": "acme/api" })
+            .as_object()
+            .expect("inputs object")
+            .clone(),
+    );
+    let err = run(&compiled, input, &mock_capabilities_with_agent(MockAgentRunner))
+        .await
+        .expect_err("an unresolvable required context source must fail the run");
+    let message = err.to_string();
+    assert!(message.contains("repo_conventions"), "{message}");
+    assert!(message.contains("optional"), "{message}");
+}
+
+#[tokio::test]
+async fn marking_that_source_optional_makes_it_survivable() {
+    let mut json = graph_json();
+    json["agents"][0]["context"][0]["optional"] = json!(true);
+    let graph = parse(json);
+    let item = run_triage(&graph, &mock_capabilities_with_agent(MockAgentRunner)).await;
+
+    // The run completes, and the block is simply absent from the request.
+    assert_eq!(item["raw"]["agent"], "triager");
 }

--- a/tests/configurable_agents_e2e.rs
+++ b/tests/configurable_agents_e2e.rs
@@ -1,0 +1,195 @@
+#![cfg(feature = "mock")]
+//! End-to-end tests for **configurable agents**: a graph that declares its own
+//! agent types, an `agent` node that narrows one, and the harness seam that
+//! receives the assembled request.
+//!
+//! These drive the real engine rather than the executor directly, so they cover
+//! the parts a unit test cannot: that the graph's top-level `agents` registry is
+//! actually threaded into node execution, that a JSON-authored workflow round
+//! trips through `serde` into a working run, and that the item envelope a
+//! downstream node reads carries the agent's stop reason.
+
+use serde_json::{Value, json};
+use tinyflows::caps::mock::{
+    MockAgentHarness, MockAgentRunner, mock_capabilities, mock_capabilities_with_agent,
+};
+use tinyflows::compiler::compile;
+use tinyflows::engine::run;
+use tinyflows::model::WorkflowGraph;
+
+/// The reference workflow: a graph-declared agent type, narrowed by the node
+/// that uses it, feeding a condition that branches on the agent's stop reason.
+fn graph_json() -> Value {
+    json!({
+        "name": "triage",
+        "inputs": [{ "name": "repo", "type": "string", "required": true }],
+        "agents": [{
+            "id": "triager",
+            "name": "Issue triager",
+            "description": "Labels and routes inbound issues.",
+            "instructions": "You triage issues for =inputs.repo.",
+            "model": "sonnet",
+            "provider": "anthropic",
+            "working_dir": "/srv/checkout",
+            "tools": [
+                { "slug": "github.search" },
+                { "slug": "github.label", "connection_ref": "conn_bot" }
+            ],
+            "context": [
+                { "kind": "host", "source": "repo_conventions", "params": { "repo": "=inputs.repo" } }
+            ],
+            "limits": { "max_steps": 8, "max_tool_calls": 20, "tool_timeout_secs": 30 },
+            "metadata": { "tier": "fast" }
+        }],
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "start", "config": { "trigger_kind": "manual" } },
+            {
+                "id": "triage", "kind": "agent", "name": "Triage",
+                "config": {
+                    "agent_ref": "triager",
+                    "prompt": "Triage this issue.",
+                    "instructions": "Prefer `bug` when a stack trace is present.",
+                    "model": "opus",
+                    "tools": [{ "slug": "github.search" }],
+                    "limits": { "max_steps": 4 },
+                    "metadata": { "run_note": "e2e" },
+                    "context": [{ "kind": "text", "label": "Repo", "text": "=inputs.repo" }]
+                }
+            }
+        ],
+        "edges": [{ "from_node": "t", "to_node": "triage" }]
+    })
+}
+
+fn parse(graph: Value) -> WorkflowGraph {
+    serde_json::from_value(graph).expect("graph deserializes")
+}
+
+/// Runs `graph` with `repo` supplied, returning the `triage` node's output item.
+async fn run_triage(graph: &WorkflowGraph, caps: &tinyflows::caps::Capabilities) -> Value {
+    let compiled = compile(graph).expect("compile");
+    let outcome = run(&compiled, json!({ "inputs": { "repo": "acme/api" } }), caps)
+        .await
+        .expect("run");
+    outcome.output["nodes"]["triage"]["items"][0]["json"].clone()
+}
+
+#[tokio::test]
+async fn a_graph_declared_agent_reaches_the_harness_merged_and_narrowed() {
+    let graph = parse(graph_json());
+    let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+    let item = run_triage(&graph, &caps).await;
+    let request = &item["json"];
+
+    assert_eq!(request["agent"], "triager");
+    assert_eq!(
+        request["instructions"], "You triage issues for acme/api.\n\nPrefer `bug` when a stack trace is present.",
+        "the definition's instructions resolved their =expression and the node's appended"
+    );
+    assert_eq!(request["model"], "opus", "the node overrode the model");
+    assert_eq!(request["provider"], "anthropic", "the definition's provider survived");
+    assert_eq!(request["working_dir"], "/srv/checkout");
+    assert_eq!(request["prompt"], "Triage this issue.");
+
+    assert_eq!(request["limits"]["max_steps"], 4, "narrowed by the node");
+    assert_eq!(request["limits"]["max_tool_calls"], 20, "left alone by the node");
+    assert_eq!(request["limits"]["tool_timeout_secs"], 30);
+
+    assert_eq!(
+        request["tools"],
+        json!(["github.search"]),
+        "the node narrowed two grants to one"
+    );
+
+    assert_eq!(request["metadata"]["tier"], "fast");
+    assert_eq!(request["metadata"]["run_note"], "e2e");
+
+    let context = request["context"].as_array().expect("context blocks");
+    assert_eq!(context.len(), 2, "the definition's block, then the node's");
+    assert_eq!(context[0]["kind"], "host");
+    assert_eq!(
+        context[0]["data"]["repo"], "acme/api",
+        "the host source's params resolved their =expression"
+    );
+    assert_eq!(context[1]["label"], "Repo");
+    assert_eq!(context[1]["text"], "acme/api");
+
+    assert_eq!(request["identity"]["node_id"], "triage");
+    assert_eq!(request["identity"]["depth"], 0);
+}
+
+#[tokio::test]
+async fn the_stop_reason_is_addressable_from_a_downstream_node() {
+    let graph = parse(graph_json());
+    let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+    let item = run_triage(&graph, &caps).await;
+
+    // `=item.meta.stop` is what lets a downstream `condition` branch on whether
+    // the agent actually reached an answer.
+    assert_eq!(item["meta"]["stop"], "finished");
+    assert_eq!(item["meta"]["agent_ref"], "triager");
+
+    // The pre-existing envelope keys are untouched.
+    assert!(item.get("json").is_some());
+    assert!(item.get("text").is_some());
+    assert!(item.get("raw").is_some());
+}
+
+#[tokio::test]
+async fn a_legacy_harness_still_receives_the_raw_config() {
+    // The non-breaking guarantee through the whole engine: `MockAgentRunner`
+    // implements only `run_agent`, so the default `run` shim forwards the node's
+    // resolved config exactly as it did before the typed seam existed.
+    let graph = parse(graph_json());
+    let caps = mock_capabilities_with_agent(MockAgentRunner);
+    let item = run_triage(&graph, &caps).await;
+
+    assert_eq!(item["raw"]["agent"], "triager");
+    assert_eq!(item["raw"]["connection"], Value::Null);
+    let forwarded = &item["raw"]["request"];
+    assert_eq!(forwarded["agent_ref"], "triager");
+    assert_eq!(forwarded["prompt"], "Triage this issue.");
+    assert_eq!(
+        forwarded["model"], "opus",
+        "the node config is forwarded verbatim, overrides and all"
+    );
+}
+
+#[tokio::test]
+async fn a_graph_without_a_registry_behaves_exactly_as_before() {
+    // No `agents` array, no new config keys, no harness — the plain completion
+    // path, byte-identical to what it has always produced.
+    let graph = parse(json!({
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "start", "config": { "trigger_kind": "manual" } },
+            { "id": "a", "kind": "agent", "name": "a", "config": { "prompt": "hi" } }
+        ],
+        "edges": [{ "from_node": "t", "to_node": "a" }]
+    }));
+    let compiled = compile(&graph).expect("compile");
+    let outcome = run(&compiled, Value::Null, &mock_capabilities())
+        .await
+        .expect("run");
+    let item = &outcome.output["nodes"]["a"]["items"][0]["json"];
+
+    assert_eq!(item["json"]["completion"]["prompt"], "hi");
+    assert!(
+        item.get("meta").is_none(),
+        "the degraded path emits the original three-key envelope, unchanged"
+    );
+}
+
+#[tokio::test]
+async fn the_registry_survives_a_json_round_trip() {
+    let graph = parse(graph_json());
+    let reserialized: WorkflowGraph =
+        serde_json::from_value(serde_json::to_value(&graph).expect("serialize"))
+            .expect("deserialize");
+    assert_eq!(graph, reserialized);
+
+    let agent = reserialized.agent("triager").expect("agent survives");
+    assert_eq!(agent.provider.as_deref(), Some("anthropic"));
+    assert_eq!(agent.working_dir.as_deref(), Some("/srv/checkout"));
+    assert_eq!(agent.limits.tool_timeout_secs, Some(30));
+    assert_eq!(agent.tools.len(), 2);
+}

--- a/tests/configurable_agents_e2e.rs
+++ b/tests/configurable_agents_e2e.rs
@@ -92,12 +92,18 @@ async fn a_graph_declared_agent_reaches_the_harness_merged_and_narrowed() {
         "the node's instructions append to the definition's rather than replacing them"
     );
     assert_eq!(request["model"], "opus", "the node overrode the model");
-    assert_eq!(request["provider"], "anthropic", "the definition's provider survived");
+    assert_eq!(
+        request["provider"], "anthropic",
+        "the definition's provider survived"
+    );
     assert_eq!(request["working_dir"], "/srv/checkout");
     assert_eq!(request["prompt"], "Triage this issue.");
 
     assert_eq!(request["limits"]["max_steps"], 4, "narrowed by the node");
-    assert_eq!(request["limits"]["max_tool_calls"], 20, "left alone by the node");
+    assert_eq!(
+        request["limits"]["max_tool_calls"], 20,
+        "left alone by the node"
+    );
     assert_eq!(request["limits"]["tool_timeout_secs"], 30);
 
     assert_eq!(
@@ -216,9 +222,13 @@ async fn a_host_context_source_a_harness_cannot_expand_fails_loudly() {
             .expect("inputs object")
             .clone(),
     );
-    let err = run(&compiled, input, &mock_capabilities_with_agent(MockAgentRunner))
-        .await
-        .expect_err("an unresolvable required context source must fail the run");
+    let err = run(
+        &compiled,
+        input,
+        &mock_capabilities_with_agent(MockAgentRunner),
+    )
+    .await
+    .expect_err("an unresolvable required context source must fail the run");
     let message = err.to_string();
     assert!(message.contains("repo_conventions"), "{message}");
     assert!(message.contains("optional"), "{message}");

--- a/tests/configurable_agents_e2e.rs
+++ b/tests/configurable_agents_e2e.rs
@@ -14,7 +14,7 @@ use tinyflows::caps::mock::{
     MockAgentHarness, MockAgentRunner, mock_capabilities, mock_capabilities_with_agent,
 };
 use tinyflows::compiler::compile;
-use tinyflows::engine::run;
+use tinyflows::engine::{RunInput, run};
 use tinyflows::model::WorkflowGraph;
 
 /// The reference workflow: a graph-declared agent type, narrowed by the node
@@ -68,9 +68,13 @@ fn parse(graph: Value) -> WorkflowGraph {
 /// Runs `graph` with `repo` supplied, returning the `triage` node's output item.
 async fn run_triage(graph: &WorkflowGraph, caps: &tinyflows::caps::Capabilities) -> Value {
     let compiled = compile(graph).expect("compile");
-    let outcome = run(&compiled, json!({ "inputs": { "repo": "acme/api" } }), caps)
-        .await
-        .expect("run");
+    let input = RunInput::new(Value::Null).with_inputs(
+        json!({ "repo": "acme/api" })
+            .as_object()
+            .expect("inputs object")
+            .clone(),
+    );
+    let outcome = run(&compiled, input, caps).await.expect("run");
     outcome.output["nodes"]["triage"]["items"][0]["json"].clone()
 }
 


### PR DESCRIPTION
## What

Makes the `agent` node richly configurable — dynamic context, an explicit tool allow-list, agent types, model/provider, working directory, timeouts, and arbitrary harness metadata — while the agent *implementation* stays entirely with the embedding harness.

**tinyflows runs no agentic loop.** The crate's job is *assembly*: turn what the author declared into one inert, fully-resolved `caps::AgentRunRequest` and hand it to the host, which owns the model↔tool loop, the transcript, and the prompt.

```
  graph `agents` registry ──┐
  AgentRunner::resolve_agent ┼─► definition ─► merge node overrides (narrowing only)
  pass-through {id}         ─┘                        │
                                                      ▼
                       context sources ─► ContextBlock[]
                       tool grants     ─► ToolDescriptor[]
                                                      │
                                                      ▼
                       AgentRunOutcome ◄── AgentRunner::run(AgentRunRequest)
```

## This release is additive

`AgentRunner::run_agent` is unchanged and remains the trait's **only required method**. The four new seams (`run`, `resolve_agent`/`list_agents`, `resolve_context`, `resolve_tools`) are all defaulted, and the default `run` forwards the node's resolved config to `run_agent` verbatim — so a host written against 0.6.1 compiles untouched and behaves byte-identically. Proven by tests at both the unit and full-engine level.

`Capabilities` gains **no fields** (which is why the new seams live on the trait rather than as new capability slots — adding a field would have broken every struct-literal construction). The item envelope's `json` / `text` / `raw` are unchanged.

**The one source-level change:** `WorkflowGraph` gains `agents`, and `NodeContext` gains `agents`. JSON round-trips are unaffected; code constructing either by *exhaustive* struct literal needs `..Default::default()` or the new field. Every in-crate site is updated here.

## What's new

- **`WorkflowGraph::agents`** — a top-level registry of reusable `model::AgentDefinition`s, mirroring `inputs`. A node's `agent_ref` resolves in-graph first (so a workflow travels between hosts), then the harness's registry, then passes through as a bare id. An unresolved ref is **not** an error — that is what a harness resolving refs internally already relied on.
- **New `agent` config keys**, all optional: `instructions`, `model`, `provider`, `working_dir`, `context`, `limits`, `metadata`. Existing keys keep their exact meaning.
- **Merge is narrowing-only** — instructions append, context appends, tools intersect, limits take the lower bound, metadata merges per key. A definition's tool `connection_ref` beats the node's, so a per-node grant cannot repoint a curated tool at another credential.
- **`ContextSource`** — `text` (literal or `=`-expression), `items`, `memory`/`flavour` (routed to the **existing** `MemoryProvider`, so the scope contract keeps exactly one home), and `host` (expanded by the harness).
- **`AgentLimits`** — `max_steps`, `max_tool_calls`, `agent_timeout_secs` (whole run) and `tool_timeout_secs` (per call). Advisory: the loop runs host-side, so the engine cannot enforce them; `node_timeout_secs` remains what it does enforce.
- **`StopReason`** — `Finished` / `LimitStop` / `Paused`, surfaced as `=item.meta.stop` on the envelope's new `meta` key. With a bare `Value` return, an agent that answered, one that stopped a step short, and one waiting on a human were indistinguishable, and the workflow marched downstream with a partial answer in every case.
- **`validate::unresolved_agent_refs`** — for hosts that want author-time resolution against their own registry.

## Deliberate design calls

- **An unresolvable context source fails the node** unless the author sets `optional: true`. Silently dropping context is the worst failure mode here: an agent missing its identity text or its connected-integration list still answers, confidently and wrongly, and that passes a smoke test.
- **`agent_ref`, tool `slug`, tool `connection_ref`, memory `scope`, and a host context `source` are literals, never `=`-expressions**, rejected structurally in `validate`. An expression resolves from run data — which may include model output — and would let upstream data choose the credential a call acts as, the tool it reaches, or the agent type (and therefore the tool grants) a turn runs with.
- **A `limit_stop` payload skips the output parser.** Validating a knowingly partial payload either fails for the wrong reason or, with `auto_fix`, spends a model call inventing the missing half.
- **`working_dir` is untrusted authoring input**, like the path fields on `ShellRequest`. The engine never touches the filesystem; the harness must validate it against its own permitted roots.
- **No new memory or context-composer trait.** `memory`/`flavour` route to `MemoryProvider`; a second read path would let the scope contract drift. And the harness owns the loop, so it owns the prompt — a composer seam here would duplicate or fight its own.

## Not in scope (deliberately)

- **Pause/resume.** `StopReason::Paused` exists so a harness can never *conflate* a pause with a finish, and no wire type changes when resume lands — but the node currently fails loudly on one. Routing a pause into `engine::resume` needs `NodeOutput::pause` + `NodeContext::resume` + interrupt plumbing, and touches ~40 test construction sites.
- **Subagent delegation and workflows-as-tools.** Both need a re-entrancy seam back into the engine.

## Testing

- `cargo test --features mock`: **705 passing**, up from 661 on main, 0 failures.
- **Every pre-existing `agent` test passes unmodified** — including all four tool-sub-port security tests, both output-parser tests, and the `agent_ref`-fallback tests. That is the non-breaking proof.
- New: merge-semantics unit tests (one per rule), validation tests, a full `tests/configurable_agents_e2e.rs` driving the real engine from JSON-authored graphs, and back-compat tests asserting a legacy host receives the byte-identical config at both levels.
- `cargo clippy --all-targets --all-features` clean, `cargo fmt` clean, `cargo test --doc` (27) clean, `cargo publish --dry-run` clean.

## Two bugs found and fixed while testing

- A `text` context source bound to `=item.count` yielded a number and failed to deserialize against a `String` field — the commonest binding in the feature failing on a type the author never wrote. `text` now accepts any JSON value.
- An unresolvable context source reported `context_0` instead of naming the source, which does not tell an author which block to fix. Unlabelled blocks now fall back to whatever identifies them.

## Migrating a harness (optional, incremental)

Override in roughly this order of value:

1. `run` — take the typed request and **map your harness's real stop reason onto `StopReason`**. A one-line shim that returns `Finished` for every run compiles, and reintroduces exactly the defect this PR removes.
2. `resolve_agent` — expose your curated agent catalogue to graphs.
3. `resolve_context` — expand `host` context sources.
4. `resolve_tools` — describe tools and expand `ns.*` patterns.
