### PR TITLE
feat: add opt-in graph visualizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +185,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -267,6 +294,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +323,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "font8x8"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875488b8711a968268c7cf5d139578713097ca4635a76044e8fe8eedf831d07e"
 
 [[package]]
 name = "form_urlencoded"
@@ -592,6 +644,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +830,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +848,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -818,6 +905,19 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -901,6 +1001,12 @@ dependencies = [
  "tempfile",
  "unarray",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -1158,6 +1264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,10 +1378,12 @@ version = "0.6.1"
 dependencies = [
  "async-trait",
  "axum",
+ "font8x8",
  "fs2",
  "futures-timer",
  "futures-util",
  "getrandom 0.4.3",
+ "image",
  "jaq-core",
  "jaq-json",
  "jaq-std",
@@ -1736,3 +1850,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ tempfile = { version = "3", optional = true }
 # `store` only: the advisory file lock that keeps two processes from deciding
 # the same proposal at once.
 fs2 = { version = "0.4", optional = true }
+# `graph-debug` only: self-contained raster output and a tiny bitmap font. The
+# renderer deliberately does not shell out to Graphviz, so it works anywhere
+# the library does.
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"], optional = true }
+font8x8 = { version = "0.3", default-features = false, features = ["unicode"], optional = true }
 jaq-core = "3.1.0"
 jaq-std = "3.0.1"
 jaq-json = { version = "2.0.1", features = ["serde"] }
@@ -61,6 +66,8 @@ host-caps = ["dep:sha2", "dep:tempfile", "tokio/fs", "tokio/process", "tokio/io-
 # A host with its own catalog or database wants none of it, so it is not part of
 # the engine. Always available inside this crate's own tests.
 store = ["dep:sha2", "dep:fs2"]
+# A file-writing graph visualizer intended for development and diagnostics.
+graph-debug = ["dep:image", "dep:font8x8"]
 
 [dev-dependencies]
 proptest = "1"

--- a/README.md
+++ b/README.md
@@ -197,6 +197,25 @@ Omitting `--features mock` is harmless: the demo body is
 `#[cfg(feature = "mock")]`-gated, so a default build stays green and the example
 just prints a hint to re-run with the feature enabled.
 
+### Visual graph debugging
+
+Enable `graph-debug` to render a workflow's nodes, port-labelled edges, branch
+flows, loops, and even dangling references to a standalone PNG or JPEG. The
+renderer is part of the library and does not require Graphviz:
+
+```toml
+tinyflows = { version = "0.6", features = ["graph-debug"] }
+```
+
+```rust,no_run
+use tinyflows::model::WorkflowGraph;
+use tinyflows::visualization::render_graph;
+
+let graph = WorkflowGraph::default();
+render_graph(&graph, "workflow.png")?; // .jpg and .jpeg are supported too
+# Ok::<(), tinyflows::visualization::GraphRenderError>(())
+```
+
 Run all of them in one go:
 
 ```sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ pub mod observability;
 #[cfg(any(test, feature = "store"))]
 pub mod store;
 pub mod validate;
+/// Render workflow structure to PNG or JPEG files for visual debugging.
+#[cfg(feature = "graph-debug")]
+pub mod visualization;
 
 /// The crate name published to crates.io.
 pub const CRATE_NAME: &str = env!("CARGO_PKG_NAME");

--- a/src/visualization.rs
+++ b/src/visualization.rs
@@ -1,0 +1,544 @@
+//! Lightweight, self-contained workflow graph rendering.
+//!
+//! This module is behind the `graph-debug` feature because it writes files and
+//! pulls in raster encoders that the workflow engine itself does not need.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use font8x8::{BASIC_FONTS, UnicodeFonts};
+use image::{ImageError, ImageFormat, Rgb, RgbImage};
+
+use crate::model::{Edge, NodeKind, WorkflowGraph};
+
+const MARGIN: i32 = 48;
+const NODE_WIDTH: i32 = 240;
+const NODE_HEIGHT: i32 = 84;
+const COLUMN_GAP: i32 = 112;
+const ROW_GAP: i32 = 64;
+const TEXT_SCALE: i32 = 2;
+
+const WHITE: Rgb<u8> = Rgb([250, 251, 253]);
+const INK: Rgb<u8> = Rgb([29, 37, 51]);
+const MUTED: Rgb<u8> = Rgb([92, 103, 122]);
+const BORDER: Rgb<u8> = Rgb([62, 74, 94]);
+const DANGLING: Rgb<u8> = Rgb([254, 226, 226]);
+
+/// Errors returned while rendering a workflow graph image.
+#[derive(Debug)]
+pub enum GraphRenderError {
+    /// The output name does not end in `.png`, `.jpg`, or `.jpeg`.
+    UnsupportedExtension(PathBuf),
+    /// The encoded image could not be written.
+    Image(ImageError),
+}
+
+impl fmt::Display for GraphRenderError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedExtension(path) => write!(
+                formatter,
+                "unsupported graph image extension for {}; use .png, .jpg, or .jpeg",
+                path.display()
+            ),
+            Self::Image(error) => write!(formatter, "could not write graph image: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for GraphRenderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::UnsupportedExtension(_) => None,
+            Self::Image(error) => Some(error),
+        }
+    }
+}
+
+impl From<ImageError> for GraphRenderError {
+    fn from(error: ImageError) -> Self {
+        Self::Image(error)
+    }
+}
+
+#[derive(Clone)]
+struct VisualNode {
+    id: String,
+    name: String,
+    kind: Option<NodeKind>,
+    dangling: bool,
+}
+
+/// Renders `graph` to a PNG or JPEG selected from `path`'s extension.
+///
+/// Nodes are arranged from left to right by flow distance. Edges carry arrows
+/// and `from_port -> to_port` labels; common branch ports use distinct colors.
+/// Edges that refer to missing nodes are retained and point to red placeholder
+/// nodes, which makes malformed graphs useful to inspect too.
+///
+/// Parent directories are not created automatically. Existing files are
+/// replaced by the image encoder.
+///
+/// # Examples
+///
+/// ```no_run
+/// use tinyflows::model::WorkflowGraph;
+/// use tinyflows::visualization::render_graph;
+///
+/// let graph = WorkflowGraph::default();
+/// render_graph(&graph, "workflow.png")?;
+/// # Ok::<(), tinyflows::visualization::GraphRenderError>(())
+/// ```
+pub fn render_graph(graph: &WorkflowGraph, path: impl AsRef<Path>) -> Result<(), GraphRenderError> {
+    let path = path.as_ref();
+    let format = image_format(path)?;
+    let nodes = visual_nodes(graph);
+    let layers = assign_layers(&nodes, &graph.edges);
+    let (positions, width, height) = place_nodes(&nodes, &layers);
+    let mut image = RgbImage::from_pixel(width, height, WHITE);
+
+    let title = if graph.name.trim().is_empty() {
+        "Workflow graph"
+    } else {
+        graph.name.trim()
+    };
+    draw_text(&mut image, MARGIN, 16, &truncate(title, 34), 2, INK);
+
+    for edge in &graph.edges {
+        draw_edge(&mut image, edge, &positions);
+    }
+    for node in &nodes {
+        if let Some(&(x, y)) = positions.get(node.id.as_str()) {
+            draw_node(&mut image, node, x, y);
+        }
+    }
+
+    image.save_with_format(path, format)?;
+    Ok(())
+}
+
+fn image_format(path: &Path) -> Result<ImageFormat, GraphRenderError> {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("png") => Ok(ImageFormat::Png),
+        Some("jpg" | "jpeg") => Ok(ImageFormat::Jpeg),
+        _ => Err(GraphRenderError::UnsupportedExtension(path.to_path_buf())),
+    }
+}
+
+fn visual_nodes(graph: &WorkflowGraph) -> Vec<VisualNode> {
+    let mut nodes = graph
+        .nodes
+        .iter()
+        .map(|node| VisualNode {
+            id: node.id.clone(),
+            name: node.name.clone(),
+            kind: Some(node.kind.clone()),
+            dangling: false,
+        })
+        .collect::<Vec<_>>();
+    let mut known = graph
+        .nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect::<HashSet<_>>();
+
+    for id in graph
+        .edges
+        .iter()
+        .flat_map(|edge| [edge.from_node.as_str(), edge.to_node.as_str()])
+    {
+        if known.insert(id) {
+            nodes.push(VisualNode {
+                id: id.to_owned(),
+                name: format!("missing: {id}"),
+                kind: None,
+                dangling: true,
+            });
+        }
+    }
+    nodes
+}
+
+fn assign_layers(nodes: &[VisualNode], edges: &[Edge]) -> HashMap<String, usize> {
+    let ids = nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect::<HashSet<_>>();
+    let mut incoming = nodes
+        .iter()
+        .map(|node| (node.id.as_str(), 0usize))
+        .collect::<HashMap<_, _>>();
+    let mut outgoing: HashMap<&str, Vec<&str>> = HashMap::new();
+    for edge in edges {
+        if ids.contains(edge.from_node.as_str()) && ids.contains(edge.to_node.as_str()) {
+            *incoming.entry(edge.to_node.as_str()).or_default() += 1;
+            outgoing
+                .entry(edge.from_node.as_str())
+                .or_default()
+                .push(edge.to_node.as_str());
+        }
+    }
+
+    let mut starts = nodes
+        .iter()
+        .filter(|node| {
+            node.kind == Some(NodeKind::Trigger)
+                || incoming.get(node.id.as_str()).copied().unwrap_or_default() == 0
+        })
+        .map(|node| node.id.as_str())
+        .collect::<Vec<_>>();
+    if starts.is_empty() && !nodes.is_empty() {
+        starts.push(nodes[0].id.as_str());
+    }
+
+    let mut layers = HashMap::new();
+    let mut queue = VecDeque::new();
+    for start in starts {
+        if layers.insert(start.to_owned(), 0).is_none() {
+            queue.push_back(start);
+        }
+    }
+    while let Some(id) = queue.pop_front() {
+        let next_layer = layers[id] + 1;
+        for &next in outgoing.get(id).into_iter().flatten() {
+            if !layers.contains_key(next) {
+                layers.insert(next.to_owned(), next_layer);
+                queue.push_back(next);
+            }
+        }
+    }
+
+    let fallback_layer =
+        layers.values().copied().max().unwrap_or(0) + usize::from(!layers.is_empty());
+    for node in nodes {
+        layers.entry(node.id.clone()).or_insert(fallback_layer);
+    }
+    layers
+}
+
+fn place_nodes(
+    nodes: &[VisualNode],
+    layers: &HashMap<String, usize>,
+) -> (HashMap<String, (i32, i32)>, u32, u32) {
+    if nodes.is_empty() {
+        return (HashMap::new(), 640, 240);
+    }
+    let max_layer = layers.values().copied().max().unwrap_or(0);
+    let mut rows = vec![0usize; max_layer + 1];
+    let mut positions = HashMap::new();
+    for node in nodes {
+        let layer = layers[node.id.as_str()];
+        let row = rows[layer];
+        rows[layer] += 1;
+        positions.insert(
+            node.id.clone(),
+            (
+                MARGIN + layer as i32 * (NODE_WIDTH + COLUMN_GAP),
+                MARGIN + row as i32 * (NODE_HEIGHT + ROW_GAP),
+            ),
+        );
+    }
+    let width = (MARGIN * 2 + NODE_WIDTH + max_layer as i32 * (NODE_WIDTH + COLUMN_GAP)) as u32;
+    let max_rows = rows.into_iter().max().unwrap_or(1).max(1);
+    let height =
+        (MARGIN * 2 + NODE_HEIGHT + (max_rows - 1) as i32 * (NODE_HEIGHT + ROW_GAP)) as u32;
+    (positions, width.max(640), height.max(240))
+}
+
+fn draw_edge(image: &mut RgbImage, edge: &Edge, positions: &HashMap<String, (i32, i32)>) {
+    let (Some(&(from_x, from_y)), Some(&(to_x, to_y))) = (
+        positions.get(edge.from_node.as_str()),
+        positions.get(edge.to_node.as_str()),
+    ) else {
+        return;
+    };
+    let start = (from_x + NODE_WIDTH, from_y + NODE_HEIGHT / 2);
+    let end = (to_x, to_y + NODE_HEIGHT / 2);
+    let color = port_color(&edge.from_port);
+    let bend_x = if end.0 > start.0 {
+        (start.0 + end.0) / 2
+    } else {
+        start.0 + 32
+    };
+    draw_line(image, start.0, start.1, bend_x, start.1, color);
+    draw_line(image, bend_x, start.1, bend_x, end.1, color);
+    draw_line(image, bend_x, end.1, end.0, end.1, color);
+    draw_line(image, end.0, end.1, end.0 - 9, end.1 - 6, color);
+    draw_line(image, end.0, end.1, end.0 - 9, end.1 + 6, color);
+
+    let label = truncate(&format!("{} -> {}", edge.from_port, edge.to_port), 18);
+    let label_width = text_width(&label, 1) + 8;
+    let label_x = bend_x - label_width / 2;
+    let label_y = (start.1.min(end.1) + (start.1 - end.1).abs() / 2) - 7;
+    fill_rect(image, label_x, label_y, label_width, 15, WHITE);
+    draw_text(image, label_x + 4, label_y + 4, &label, 1, color);
+}
+
+fn draw_node(image: &mut RgbImage, node: &VisualNode, x: i32, y: i32) {
+    let fill = if node.dangling {
+        DANGLING
+    } else {
+        node_fill(node.kind.as_ref())
+    };
+    fill_rect(image, x, y, NODE_WIDTH, NODE_HEIGHT, fill);
+    stroke_rect(image, x, y, NODE_WIDTH, NODE_HEIGHT, BORDER);
+    fill_rect(image, x, y, 8, NODE_HEIGHT, node_accent(node.kind.as_ref()));
+    draw_text(
+        image,
+        x + 20,
+        y + 16,
+        &truncate(&node.name, 25),
+        TEXT_SCALE,
+        INK,
+    );
+    let kind = node
+        .kind
+        .as_ref()
+        .map(kind_name)
+        .unwrap_or("dangling reference");
+    draw_text(image, x + 20, y + 48, kind, 1, MUTED);
+    draw_text(
+        image,
+        x + NODE_WIDTH - text_width(&truncate(&node.id, 12), 1) - 12,
+        y + NODE_HEIGHT - 16,
+        &truncate(&node.id, 12),
+        1,
+        MUTED,
+    );
+}
+
+fn kind_name(kind: &NodeKind) -> &'static str {
+    match kind {
+        NodeKind::Trigger => "trigger",
+        NodeKind::Agent => "agent",
+        NodeKind::ToolCall => "tool_call",
+        NodeKind::HttpRequest => "http_request",
+        NodeKind::Code => "code",
+        NodeKind::Shell => "shell",
+        NodeKind::Condition => "condition",
+        NodeKind::Switch => "switch",
+        NodeKind::Merge => "merge",
+        NodeKind::SplitOut => "split_out",
+        NodeKind::Loop => "loop",
+        NodeKind::Transform => "transform",
+        NodeKind::OutputParser => "output_parser",
+        NodeKind::SubWorkflow => "sub_workflow",
+        NodeKind::Memory => "memory",
+        NodeKind::Dedup => "dedup",
+    }
+}
+
+fn node_fill(kind: Option<&NodeKind>) -> Rgb<u8> {
+    match kind {
+        Some(NodeKind::Trigger) => Rgb([224, 242, 254]),
+        Some(NodeKind::Condition | NodeKind::Switch | NodeKind::Loop) => Rgb([254, 249, 195]),
+        Some(NodeKind::Merge | NodeKind::SplitOut) => Rgb([237, 233, 254]),
+        Some(NodeKind::Agent | NodeKind::ToolCall | NodeKind::HttpRequest | NodeKind::Memory) => {
+            Rgb([220, 252, 231])
+        }
+        _ => Rgb([241, 245, 249]),
+    }
+}
+
+fn node_accent(kind: Option<&NodeKind>) -> Rgb<u8> {
+    match kind {
+        Some(NodeKind::Trigger) => Rgb([2, 132, 199]),
+        Some(NodeKind::Condition | NodeKind::Switch | NodeKind::Loop) => Rgb([202, 138, 4]),
+        Some(NodeKind::Merge | NodeKind::SplitOut) => Rgb([124, 58, 237]),
+        Some(NodeKind::Agent | NodeKind::ToolCall | NodeKind::HttpRequest | NodeKind::Memory) => {
+            Rgb([22, 163, 74])
+        }
+        None => Rgb([220, 38, 38]),
+        _ => Rgb([71, 85, 105]),
+    }
+}
+
+fn port_color(port: &str) -> Rgb<u8> {
+    match port {
+        "true" => Rgb([22, 163, 74]),
+        "false" => Rgb([217, 119, 6]),
+        "error" => Rgb([220, 38, 38]),
+        "body" => Rgb([124, 58, 237]),
+        "done" => Rgb([13, 148, 136]),
+        _ => Rgb([37, 99, 235]),
+    }
+}
+
+fn truncate(text: &str, max_chars: usize) -> String {
+    let mut chars = text.chars();
+    let prefix = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!(
+            "{}...",
+            prefix
+                .chars()
+                .take(max_chars.saturating_sub(3))
+                .collect::<String>()
+        )
+    } else {
+        prefix
+    }
+}
+
+fn text_width(text: &str, scale: i32) -> i32 {
+    text.chars().count() as i32 * 8 * scale
+}
+
+fn draw_text(image: &mut RgbImage, x: i32, y: i32, text: &str, scale: i32, color: Rgb<u8>) {
+    for (index, character) in text.chars().enumerate() {
+        let glyph = BASIC_FONTS.get(character).or_else(|| BASIC_FONTS.get('?'));
+        let Some(glyph) = glyph else { continue };
+        for (row, bits) in glyph.into_iter().enumerate() {
+            for column in 0..8 {
+                if bits & (1 << column) != 0 {
+                    fill_rect(
+                        image,
+                        x + (index as i32 * 8 + column) * scale,
+                        y + row as i32 * scale,
+                        scale,
+                        scale,
+                        color,
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn fill_rect(image: &mut RgbImage, x: i32, y: i32, width: i32, height: i32, color: Rgb<u8>) {
+    for pixel_y in y.max(0)..(y + height).min(image.height() as i32) {
+        for pixel_x in x.max(0)..(x + width).min(image.width() as i32) {
+            image.put_pixel(pixel_x as u32, pixel_y as u32, color);
+        }
+    }
+}
+
+fn stroke_rect(image: &mut RgbImage, x: i32, y: i32, width: i32, height: i32, color: Rgb<u8>) {
+    draw_line(image, x, y, x + width, y, color);
+    draw_line(image, x + width, y, x + width, y + height, color);
+    draw_line(image, x + width, y + height, x, y + height, color);
+    draw_line(image, x, y + height, x, y, color);
+}
+
+fn draw_line(image: &mut RgbImage, mut x0: i32, mut y0: i32, x1: i32, y1: i32, color: Rgb<u8>) {
+    let dx = (x1 - x0).abs();
+    let sx = if x0 < x1 { 1 } else { -1 };
+    let dy = -(y1 - y0).abs();
+    let sy = if y0 < y1 { 1 } else { -1 };
+    let mut error = dx + dy;
+    loop {
+        if x0 >= 0 && y0 >= 0 && x0 < image.width() as i32 && y0 < image.height() as i32 {
+            image.put_pixel(x0 as u32, y0 as u32, color);
+        }
+        if x0 == x1 && y0 == y1 {
+            break;
+        }
+        let doubled = 2 * error;
+        if doubled >= dy {
+            error += dy;
+            x0 += sx;
+        }
+        if doubled <= dx {
+            error += dx;
+            y0 += sy;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Edge, Node};
+
+    fn graph() -> WorkflowGraph {
+        WorkflowGraph {
+            name: "branching demo".into(),
+            nodes: vec![
+                Node {
+                    id: "start".into(),
+                    kind: NodeKind::Trigger,
+                    type_version: 1,
+                    name: "Start".into(),
+                    config: serde_json::Value::Null,
+                    ports: vec![],
+                    position: None,
+                },
+                Node {
+                    id: "check".into(),
+                    kind: NodeKind::Condition,
+                    type_version: 1,
+                    name: "Check input".into(),
+                    config: serde_json::Value::Null,
+                    ports: vec![],
+                    position: None,
+                },
+            ],
+            edges: vec![
+                Edge {
+                    from_node: "start".into(),
+                    from_port: "main".into(),
+                    to_node: "check".into(),
+                    to_port: "main".into(),
+                },
+                Edge {
+                    from_node: "check".into(),
+                    from_port: "error".into(),
+                    to_node: "missing".into(),
+                    to_port: "main".into(),
+                },
+            ],
+            ..WorkflowGraph::default()
+        }
+    }
+
+    #[test]
+    fn renders_png_and_dangling_edge_endpoint() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("graph.PNG");
+        render_graph(&graph(), &path).expect("render graph");
+        let bytes = std::fs::read(&path).expect("read image");
+        assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
+        let image = image::open(path).expect("decode image");
+        assert!(image.width() >= 640);
+        assert!(image.height() >= 240);
+    }
+
+    #[test]
+    fn renders_jpeg_from_jpg_or_jpeg_extension() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        for extension in ["jpg", "jpeg"] {
+            let path = directory.path().join(format!("graph.{extension}"));
+            render_graph(&graph(), &path).expect("render graph");
+            let bytes = std::fs::read(path).expect("read image");
+            assert_eq!(&bytes[..2], b"\xff\xd8");
+        }
+    }
+
+    #[test]
+    fn rejects_an_unknown_output_format_before_writing() {
+        let path = Path::new("graph.gif");
+        let error = render_graph(&graph(), path).expect_err("unsupported format");
+        assert!(matches!(error, GraphRenderError::UnsupportedExtension(_)));
+        assert!(error.to_string().contains(".png, .jpg, or .jpeg"));
+    }
+
+    #[test]
+    fn cycle_layout_terminates_and_places_every_node() {
+        let nodes = visual_nodes(&graph());
+        let mut edges = graph().edges;
+        edges.push(Edge {
+            from_node: "missing".into(),
+            from_port: "main".into(),
+            to_node: "check".into(),
+            to_port: "main".into(),
+        });
+        let layers = assign_layers(&nodes, &edges);
+        assert_eq!(layers.len(), nodes.len());
+    }
+}


### PR DESCRIPTION
## Summary

- add a self-contained `visualization::render_graph` library helper behind the default-off `graph-debug` feature
- render left-to-right workflow nodes and directed, port-labelled flows to PNG or JPEG without requiring Graphviz
- highlight branch/error/loop ports and preserve dangling endpoints as diagnostic placeholder nodes
- document feature opt-in and usage

## Validation

- `cargo test --all-features`
- `cargo test --doc --features graph-debug`
- `cargo check --no-default-features`
- `cargo clippy --all-targets --features graph-debug -- -D warnings`
- `git diff --check`