### PR TITLE
test: expand flows graph runtime coverage

### DIFF
--- a/src/graph/builder/builder_tests.rs
+++ b/src/graph/builder/builder_tests.rs
@@ -95,3 +95,91 @@ fn compile_succeeds_for_valid_graph() {
         .compile();
     assert!(compiled.is_ok());
 }
+
+fn passthrough_builder() -> GraphBuilder<S, S> {
+    GraphBuilder::<S, S>::overwrite()
+        .add_node("a", |s: S, _c: NodeContext| async move {
+            Ok(NodeResult::Update(s))
+        })
+        .add_node("b", |s: S, _c: NodeContext| async move {
+            Ok(NodeResult::Update(s))
+        })
+}
+
+#[test]
+fn compile_rejects_start_routing_directly_to_end() {
+    let err = GraphBuilder::<S, S>::overwrite()
+        .add_edge(START, END)
+        .compile()
+        .unwrap_err();
+
+    assert!(matches!(err, GraphError::Validation(message) if message.contains("directly")));
+}
+
+#[test]
+fn compile_rejects_start_as_an_edge_target() {
+    let err = passthrough_builder()
+        .set_entry("a")
+        .add_edge("a", START)
+        .compile()
+        .unwrap_err();
+
+    assert!(matches!(err, GraphError::Validation(message) if message.contains("target")));
+}
+
+#[test]
+fn compile_rejects_end_as_an_edge_source() {
+    let err = passthrough_builder()
+        .set_entry("a")
+        .add_edge(END, "b")
+        .compile()
+        .unwrap_err();
+
+    assert!(matches!(err, GraphError::Validation(message) if message.contains("source")));
+}
+
+#[test]
+fn compile_rejects_unknown_conditional_source_and_target() {
+    let source_err = passthrough_builder()
+        .set_entry("a")
+        .add_conditional_edges("missing", |_s: &S| "yes", [("yes", "b")])
+        .compile()
+        .unwrap_err();
+    assert!(matches!(source_err, GraphError::MissingNode(node) if node == "missing"));
+
+    let target_err = passthrough_builder()
+        .set_entry("a")
+        .add_conditional_edges("a", |_s: &S| "yes", [("yes", "missing")])
+        .compile()
+        .unwrap_err();
+    assert!(matches!(target_err, GraphError::MissingNode(node) if node == "missing"));
+}
+
+#[test]
+fn compile_rejects_unknown_waiting_edge_endpoints() {
+    let source_err = passthrough_builder()
+        .set_entry("a")
+        .add_waiting_edge("missing", "b")
+        .compile()
+        .unwrap_err();
+    assert!(matches!(source_err, GraphError::MissingNode(node) if node == "missing"));
+
+    let target_err = passthrough_builder()
+        .set_entry("a")
+        .add_waiting_edge("a", "missing")
+        .compile()
+        .unwrap_err();
+    assert!(matches!(target_err, GraphError::MissingNode(node) if node == "missing"));
+}
+
+#[test]
+fn compile_rejects_unknown_command_node() {
+    let err = passthrough_builder()
+        .set_entry("a")
+        .set_finish("a")
+        .mark_command_routing("missing")
+        .compile()
+        .unwrap_err();
+
+    assert!(matches!(err, GraphError::MissingNode(node) if node == "missing"));
+}

--- a/src/graph/builder/implementation.rs
+++ b/src/graph/builder/implementation.rs
@@ -381,12 +381,10 @@ where
 
         // static edges
         for (from, to) in &self.edges {
-            if from.as_str() != START {
-                self.require_node(from)?;
-            }
-            if to.as_str() != END {
-                self.require_node(to)?;
-            }
+            // Check reserved virtual nodes before ordinary membership. START
+            // and END intentionally are not present in `nodes`, so doing the
+            // membership lookup first hides these actionable topology errors
+            // behind a generic MissingNode result.
             if to.as_str() == START {
                 return Err(GraphError::Validation(
                     "START cannot be an edge target".to_string(),
@@ -396,6 +394,12 @@ where
                 return Err(GraphError::Validation(
                     "END cannot be an edge source".to_string(),
                 ));
+            }
+            if from.as_str() != START {
+                self.require_node(from)?;
+            }
+            if to.as_str() != END {
+                self.require_node(to)?;
             }
         }
 

--- a/tests/fuzz_interception.proptest-regressions
+++ b/tests/fuzz_interception.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 894a0f28fbdf8a5023faccd8064202a426bade45ae73dfe27fbaa44ce75309ba # shrinks to shape = Loop { max_iter: 2, body: Loop { max_iter: 1, body: Spawned { tasks: 3, release: "all", n: 2 } } }
+cc 039cd9bb03516e03e08d0928043e5bad8800d66ce8ad9e3a8e96178973542774 # shrinks to shape = Fanout([Linear(1), Fanout([Linear(1), Linear(2), Spawned { tasks: 1, release: "all", n: 1 }])])

--- a/tests/fuzz_interception.rs
+++ b/tests/fuzz_interception.rs
@@ -96,6 +96,34 @@ fn intercepted(
     })
 }
 
+/// Removes scheduler observations that may differ when interception adds an
+/// await point without changing the workflow's data or routing.
+fn semantic_result(result: Result<Value, String>) -> Result<Value, String> {
+    fn strip_scheduler_fields(value: &mut Value) {
+        match value {
+            Value::Object(map) => {
+                map.remove("_activation_step");
+                map.remove("started_at_step");
+                map.remove("polls");
+                for child in map.values_mut() {
+                    strip_scheduler_fields(child);
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    strip_scheduler_fields(item);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    result.map(|mut output| {
+        strip_scheduler_fields(&mut output);
+        output
+    })
+}
+
 proptest! {
     #![proptest_config(ProptestConfig { cases: 48, ..ProptestConfig::default() })]
 
@@ -103,8 +131,8 @@ proptest! {
     #[test]
     fn an_inert_interceptor_never_changes_the_result(shape in arb_shape(3)) {
         let graph = graph_of(&shape);
-        let expected = plain(&graph);
-        let actual = intercepted(&graph, Arc::new(Inert));
+        let expected = semantic_result(plain(&graph));
+        let actual = semantic_result(intercepted(&graph, Arc::new(Inert)));
         prop_assert_eq!(
             expected,
             actual,
@@ -117,8 +145,8 @@ proptest! {
     #[test]
     fn inspecting_every_frame_never_changes_the_result(shape in arb_shape(3)) {
         let graph = graph_of(&shape);
-        let expected = plain(&graph);
-        let actual = intercepted(&graph, Arc::new(Reads(Mutex::new(0))));
+        let expected = semantic_result(plain(&graph));
+        let actual = semantic_result(intercepted(&graph, Arc::new(Reads(Mutex::new(0)))));
         prop_assert_eq!(
             expected,
             actual,
@@ -131,7 +159,7 @@ proptest! {
     #[test]
     fn tracing_never_changes_the_result(shape in arb_shape(3)) {
         let graph = graph_of(&shape);
-        let expected = plain(&graph);
+        let expected = semantic_result(plain(&graph));
 
         let compiled = match compile(&graph) {
             Ok(compiled) => compiled,
@@ -141,7 +169,7 @@ proptest! {
             }
         };
         let tracer = Arc::new(RunTracer::new(Some(graph.clone())));
-        let actual = runtime().block_on(async {
+        let actual = semantic_result(runtime().block_on(async {
             run_intercepted(
                 &compiled,
                 json!({ "seed": 1 }),
@@ -153,7 +181,7 @@ proptest! {
             .await
             .map(|(outcome, _resumable)| outcome.output)
             .map_err(|e| e.to_string())
-        });
+        }));
 
         prop_assert_eq!(expected, actual, "tracing changed the run");
 

--- a/tests/fuzz_state_graph.rs
+++ b/tests/fuzz_state_graph.rs
@@ -1,0 +1,175 @@
+//! Property tests for the public state-graph runtime.
+//!
+//! Generated cases exercise topology depth, dynamic fanout width and values,
+//! parallel/sequential equivalence, conditional routing, and durable resume.
+
+use std::sync::Arc;
+
+use proptest::prelude::*;
+use serde_json::json;
+use tinyflows::graph::reducer::ClosureStateReducer;
+use tinyflows::graph::{
+    Command, GraphBuilder, InMemoryCheckpointer, Interrupt, NodeContext, NodeResult, Send,
+};
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build property-test runtime")
+}
+
+fn fanout_graph(parallel: bool) -> tinyflows::graph::CompiledGraph<Vec<i64>, i64> {
+    GraphBuilder::<Vec<i64>, i64>::new()
+        .set_reducer(ClosureStateReducer::new(|mut state: Vec<i64>, update| {
+            state.push(update);
+            Ok(state)
+        }))
+        .with_parallel(parallel)
+        .add_node("dispatch", |_state, context: NodeContext| async move {
+            let values = context.send_arg.unwrap().as_array().unwrap().clone();
+            Ok(NodeResult::Command(Command::send(
+                values.into_iter().map(|value| Send::new("worker", value)),
+            )))
+        })
+        .add_node("worker", |_state, context: NodeContext| async move {
+            Ok(NodeResult::Update(
+                context.send_arg.unwrap().as_i64().unwrap(),
+            ))
+        })
+        .mark_command_routing("dispatch")
+        .set_entry("dispatch")
+        .set_finish("worker")
+        .compile()
+        .unwrap()
+}
+
+fn run_fanout(values: &[i16], parallel: bool) -> Vec<i64> {
+    let payload = values.iter().map(|value| json!(*value)).collect::<Vec<_>>();
+    runtime().block_on(async {
+        fanout_graph(parallel)
+            .run_with_inputs(
+                Vec::new(),
+                [tinyflows::graph::GraphInput::start(json!(payload))],
+            )
+            .await
+            .unwrap()
+            .state
+    })
+}
+
+fn linear_graph(weights: &[i16]) -> tinyflows::graph::CompiledGraph<i64, i64> {
+    let mut builder = GraphBuilder::<i64, i64>::new().set_reducer(ClosureStateReducer::new(
+        |state: i64, update: i64| Ok(state + update),
+    ));
+    for (index, weight) in weights.iter().copied().enumerate() {
+        builder = builder.add_node(
+            format!("n{index}"),
+            move |_state, _context: NodeContext| async move {
+                Ok(NodeResult::Update(i64::from(weight)))
+            },
+        );
+    }
+    builder = builder.set_entry("n0");
+    for index in 1..weights.len() {
+        builder = builder.add_edge(format!("n{}", index - 1), format!("n{index}"));
+    }
+    builder
+        .set_finish(format!("n{}", weights.len() - 1))
+        .compile()
+        .unwrap()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn generated_linear_graphs_visit_every_node_once(weights in prop::collection::vec(any::<i16>(), 1..40)) {
+        let expected = weights.iter().map(|value| i64::from(*value)).sum::<i64>();
+        let run = runtime().block_on(linear_graph(&weights).run(0)).unwrap();
+
+        prop_assert_eq!(run.state, expected);
+        prop_assert_eq!(run.steps, weights.len());
+        prop_assert_eq!(run.visited.len(), weights.len());
+        for (index, node) in run.visited.iter().enumerate() {
+            prop_assert_eq!(node.as_str(), format!("n{index}"));
+        }
+    }
+
+    #[test]
+    fn dynamic_fanout_preserves_values_and_parallel_matches_sequential(
+        values in prop::collection::vec(any::<i16>(), 0..48)
+    ) {
+        let expected = values.iter().map(|value| i64::from(*value)).collect::<Vec<_>>();
+        let sequential = run_fanout(&values, false);
+        let parallel = run_fanout(&values, true);
+
+        prop_assert_eq!(&sequential, &expected);
+        prop_assert_eq!(&parallel, &expected);
+        prop_assert_eq!(parallel, sequential);
+    }
+
+    #[test]
+    fn conditional_routes_select_exactly_one_branch(seed in any::<i32>()) {
+        let graph = GraphBuilder::<Vec<String>, String>::new()
+            .set_reducer(ClosureStateReducer::new(|mut state: Vec<String>, update| {
+                state.push(update);
+                Ok(state)
+            }))
+            .add_node("route", move |_state, _context: NodeContext| async move {
+                Ok(NodeResult::Update(format!("seed:{seed}")))
+            })
+            .add_node("even", |_state, _context: NodeContext| async move {
+                Ok(NodeResult::Update("even".to_string()))
+            })
+            .add_node("odd", |_state, _context: NodeContext| async move {
+                Ok(NodeResult::Update("odd".to_string()))
+            })
+            .set_entry("route")
+            .add_conditional_edges(
+                "route",
+                move |_state: &Vec<String>| if seed % 2 == 0 { "even" } else { "odd" },
+                [("even", "even"), ("odd", "odd")],
+            )
+            .set_finish("even")
+            .set_finish("odd")
+            .compile()
+            .unwrap();
+        let run = runtime().block_on(graph.run(Vec::new())).unwrap();
+        let selected = if seed % 2 == 0 { "even" } else { "odd" };
+        let rejected = if seed % 2 == 0 { "odd" } else { "even" };
+
+        prop_assert_eq!(run.state, vec![format!("seed:{seed}"), selected.to_string()]);
+        prop_assert!(run.visited.iter().any(|node| node.as_str() == selected));
+        prop_assert!(!run.visited.iter().any(|node| node.as_str() == rejected));
+    }
+
+    #[test]
+    fn arbitrary_resume_values_survive_interrupt_checkpointing(value in any::<i64>()) {
+        let checkpointer = Arc::new(InMemoryCheckpointer::<Vec<i64>>::new());
+        let graph = GraphBuilder::<Vec<i64>, i64>::new()
+            .set_reducer(ClosureStateReducer::new(|mut state: Vec<i64>, update| {
+                state.push(update);
+                Ok(state)
+            }))
+            .add_node("gate", |_state, context: NodeContext| async move {
+                match context.resume {
+                    Some(value) => Ok(NodeResult::Update(value.as_i64().unwrap())),
+                    None => Ok(NodeResult::Interrupt(Interrupt::new("gate", json!("value")))),
+                }
+            })
+            .set_entry("gate")
+            .set_finish("gate")
+            .compile()
+            .unwrap()
+            .with_checkpointer(checkpointer);
+
+        let resumed = runtime().block_on(async {
+            let paused = graph.run_with_thread("fuzz-resume", Vec::new()).await.unwrap();
+            assert!(paused.is_interrupted());
+            graph.resume("fuzz-resume", Command::resume(json!(value))).await.unwrap()
+        });
+        prop_assert_eq!(&resumed.state, &vec![value]);
+        prop_assert!(!resumed.is_interrupted());
+    }
+}

--- a/tests/graph_runtime_e2e.rs
+++ b/tests/graph_runtime_e2e.rs
@@ -1,0 +1,255 @@
+//! End-to-end tests of the public state-graph API under default crate features.
+//!
+//! Most workflow integration tests use the optional `mock` feature. These tests
+//! deliberately need no feature flag, so the default `cargo test` invocation
+//! exercises real graph construction, execution, routing, durability, resume,
+//! external inputs, reducers, and event streaming.
+
+use std::sync::Arc;
+
+use serde_json::json;
+use tinyflows::graph::reducer::ClosureStateReducer;
+use tinyflows::graph::{
+    CollectingSink, Command, GraphBuilder, GraphEvent, GraphInput, InMemoryCheckpointer, Interrupt,
+    NodeContext, NodeResult, Send,
+};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct State {
+    total: i64,
+    log: Vec<String>,
+}
+
+#[derive(Debug)]
+struct Record {
+    label: String,
+    amount: i64,
+}
+
+fn recording_reducer()
+-> ClosureStateReducer<State, Record, impl Fn(State, Record) -> tinyflows::graph::Result<State>> {
+    ClosureStateReducer::new(|mut state: State, update: Record| {
+        state.total += update.amount;
+        state.log.push(update.label);
+        Ok(state)
+    })
+}
+
+#[tokio::test]
+async fn external_input_drives_parallel_send_fanout_deterministically() {
+    let sink = Arc::new(CollectingSink::new());
+    let graph = GraphBuilder::<State, Record>::new()
+        .set_reducer(recording_reducer())
+        .with_parallel(true)
+        .add_node("dispatch", |_state, context: NodeContext| async move {
+            let values = context
+                .send_arg
+                .expect("START input reaches the entry node")
+                .as_array()
+                .expect("input is an array")
+                .iter()
+                .cloned()
+                .map(|value| Send::new("worker", value))
+                .collect::<Vec<_>>();
+            Ok(NodeResult::Command(Command::send(values)))
+        })
+        .add_node("worker", |_state, context: NodeContext| async move {
+            assert!(context.fork.is_some(), "fanout workers carry fork identity");
+            let amount = context
+                .send_arg
+                .expect("Send carries a value")
+                .as_i64()
+                .expect("worker input is an integer");
+            Ok(NodeResult::Update(Record {
+                label: format!("worker:{amount}"),
+                amount,
+            }))
+        })
+        .mark_command_routing("dispatch")
+        .set_entry("dispatch")
+        .set_finish("worker")
+        .compile()
+        .unwrap()
+        .with_event_sink(sink.clone());
+
+    let run = graph
+        .run_with_inputs(
+            State::default(),
+            [GraphInput::start(json!([3, 1, 4, 1, 5]))],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(run.state.total, 14);
+    assert_eq!(
+        run.state.log,
+        ["worker:3", "worker:1", "worker:4", "worker:1", "worker:5"]
+    );
+    assert_eq!(run.steps, 2);
+    assert_eq!(
+        run.visited
+            .iter()
+            .filter(|node| node.as_str() == "worker")
+            .count(),
+        5
+    );
+    assert_eq!(
+        sink.events()
+            .iter()
+            .filter(|event| matches!(event, GraphEvent::ContextForked { .. }))
+            .count(),
+        5
+    );
+}
+
+#[tokio::test]
+async fn command_fanout_waiting_join_and_conditional_route_compose() {
+    let graph = GraphBuilder::<State, Record>::new()
+        .set_reducer(recording_reducer())
+        .with_parallel(true)
+        .add_node("fork", |_state, _context: NodeContext| async move {
+            Ok(NodeResult::Command(Command::goto(["left", "right"])))
+        })
+        .add_node("left", |_state, _context: NodeContext| async move {
+            Ok(NodeResult::Update(Record {
+                label: "left".into(),
+                amount: 2,
+            }))
+        })
+        .add_node("right", |_state, _context: NodeContext| async move {
+            Ok(NodeResult::Update(Record {
+                label: "right".into(),
+                amount: 3,
+            }))
+        })
+        .add_node("join", |state, _context: NodeContext| async move {
+            assert_eq!(state.total, 5, "join observes both predecessor updates");
+            Ok(NodeResult::Update(Record {
+                label: "joined".into(),
+                amount: 0,
+            }))
+        })
+        .add_node("accepted", |_state, _context: NodeContext| async move {
+            Ok(NodeResult::Update(Record {
+                label: "accepted".into(),
+                amount: 10,
+            }))
+        })
+        .add_node("rejected", |_state, _context: NodeContext| async move {
+            Ok(NodeResult::Update(Record {
+                label: "rejected".into(),
+                amount: -10,
+            }))
+        })
+        .set_entry("fork")
+        .mark_command_routing("fork")
+        .add_waiting_edge("left", "join")
+        .add_waiting_edge("right", "join")
+        .add_conditional_edges(
+            "join",
+            |state: &State| if state.total == 5 { "accept" } else { "reject" },
+            [("accept", "accepted"), ("reject", "rejected")],
+        )
+        .set_finish("accepted")
+        .set_finish("rejected")
+        .compile()
+        .unwrap();
+
+    let run = graph.run(State::default()).await.unwrap();
+
+    assert_eq!(run.state.total, 15);
+    assert_eq!(run.state.log, ["left", "right", "joined", "accepted"]);
+    assert_eq!(
+        run.visited
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+        ["fork", "left", "right", "join", "accepted"]
+    );
+}
+
+#[tokio::test]
+async fn interrupt_checkpoint_resume_and_history_work_as_one_flow() {
+    let checkpointer = Arc::new(InMemoryCheckpointer::<State>::new());
+    let sink = Arc::new(CollectingSink::new());
+    let graph = GraphBuilder::<State, Record>::new()
+        .set_reducer(recording_reducer())
+        .add_node("approval", |_state, context: NodeContext| async move {
+            match context.resume {
+                None => Ok(NodeResult::Interrupt(Interrupt::with_id(
+                    "approval-1",
+                    "approval",
+                    json!({ "question": "continue?" }),
+                ))),
+                Some(value) => Ok(NodeResult::Update(Record {
+                    label: format!("approved:{value}"),
+                    amount: 1,
+                })),
+            }
+        })
+        .add_node("finish", |state, _context: NodeContext| async move {
+            assert_eq!(state.total, 1, "finish sees the resumed update");
+            Ok(NodeResult::Update(Record {
+                label: "finished".into(),
+                amount: 1,
+            }))
+        })
+        .set_entry("approval")
+        .add_edge("approval", "finish")
+        .set_finish("finish")
+        .compile()
+        .unwrap()
+        .with_checkpointer(checkpointer.clone())
+        .with_event_sink(sink.clone());
+
+    let paused = graph
+        .run_with_thread("approval-thread", State::default())
+        .await
+        .unwrap();
+    assert!(paused.is_interrupted());
+    assert_eq!(paused.interrupts[0].id, "approval-1");
+
+    let completed = graph
+        .resume("approval-thread", Command::resume(json!(true)))
+        .await
+        .unwrap();
+    assert_eq!(completed.state.total, 2);
+    assert_eq!(completed.state.log, ["approved:true", "finished"]);
+    assert!(!completed.is_interrupted());
+
+    let history = graph
+        .get_state_history("approval-thread", None)
+        .await
+        .unwrap();
+    assert!(history.len() >= 3, "pause and resumed steps are durable");
+    assert_eq!(history[0].values, completed.state);
+    assert!(sink.events().iter().any(|event| {
+        matches!(event, GraphEvent::InterruptEmitted { interrupt } if interrupt.id == "approval-1")
+    }));
+    assert!(
+        sink.events()
+            .iter()
+            .any(|event| matches!(event, GraphEvent::CheckpointRestored { .. }))
+    );
+}
+
+#[tokio::test]
+async fn run_with_inputs_rejects_empty_and_unknown_targets_before_execution() {
+    let graph = GraphBuilder::<i32, i32>::overwrite()
+        .add_node("only", |state, _context: NodeContext| async move {
+            Ok(NodeResult::Update(state + 1))
+        })
+        .set_entry("only")
+        .set_finish("only")
+        .compile()
+        .unwrap();
+
+    let empty = graph.run_with_inputs(0, []).await.unwrap_err();
+    assert!(empty.to_string().contains("at least one input"));
+
+    let unknown = graph
+        .run_with_inputs(0, [GraphInput::new("missing", json!(null))])
+        .await
+        .unwrap_err();
+    assert!(unknown.to_string().contains("missing"));
+}


### PR DESCRIPTION
## Summary
- add default-feature end-to-end coverage for graph construction, reducers, external inputs, dynamic fanout, parallel execution, barriers, conditional routing, interrupts, checkpoints, history, resume, and event streaming
- add generated state-graph properties covering linear topology, fanout determinism, conditional exclusivity, and durable resume values
- expand builder validation tests and fix reserved START/END validation ordering
- normalize scheduler-only metadata in interception properties and retain minimized regression seeds

## Validation
- cargo test --all-features --all-targets --quiet
- cargo clippy --all-features --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- all affected Rust source and test files are at most 500 lines