### PR TITLE
fix(adaptive): loosen rusqlite to ^0.40

### DIFF
--- a/crates/adaptive/Cargo.toml
+++ b/crates/adaptive/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
 thiserror = "2"
-rusqlite = { version = "0.40.2", features = ["bundled"], optional = true }
+rusqlite = { version = "0.40", features = ["bundled"], optional = true }
 mongodb = { version = "3.6.0", optional = true }
 
 [features]


### PR DESCRIPTION
A host workspace that also links a crate pinning `rusqlite = "=0.40.0"` (medulla's vendored OpenHuman core does) cannot resolve `^0.40.2` beside it — cargo unifies one semver-compatible range and the two requirements conflict. Nothing in the adaptive crate needs the point release, so the requirement is now `"0.40"`.

Found wiring `tinyflows-adaptive` into medulla as a vendored path dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)