### PR TITLE
feat(engine): resolve a working directory for agent and sub_workflow steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,13 +71,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   review reads it, since one resume value is delivered to every interrupted
   node.
 
-- **A directory key a node does not read is now a validation error.** `workdir`,
-  `working_directory`, `workspace` and friends on an `agent` node — or a
-  top-level `cwd` on a `tool_call` node, whose working directory belongs in
-  `args.cwd` — used to be accepted, persisted, and silently ignored, leaving the
-  step running in the workspace with nothing anywhere saying so. The message
-  names the key the node actually reads.
-
 - **`tinyflows::testkit` — testing, mocking, and live debugging for workflows.**
   Behind the default-off `testkit` feature; adds no dependencies.
 
@@ -138,6 +131,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and would have fired every on-error breakpoint on it.
 
 ### Changed
+
+- **A directory key a node does not read is now a validation error.** `workdir`,
+  `working_directory`, `workspace` and friends on an `agent` node — or a
+  top-level `cwd` on a `tool_call` node, whose working directory belongs in
+  `args.cwd` — used to be accepted, persisted, and silently ignored, leaving the
+  step running in the workspace with nothing anywhere saying so. The message
+  names the key the node actually reads.
 
 - **Breaking: the Chrome companion moved behind the `chrome-extension`
   feature.** `tinyflows::browser` and `tinyflows::companion` — previously part

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an `approvals: Option<Arc<dyn ApprovalProvider>>` field, so add
   `approvals: None` (or a provider) to keep compiling.
 
+- **Working-directory resolution for `agent` and `sub_workflow` nodes.** A run
+  is pinned to one workspace (the trigger's `config.workspace`, or a `workspace`
+  key on the trigger payload), and a node may now say where inside it the step
+  runs: `cwd` on an `agent` node (`working_dir` remains accepted as the older
+  spelling), `workspace` on a `sub_workflow` node to re-pin the child run. Both
+  are `=`-bindable, so a step can run in a directory an earlier node created.
+  The containment rule is the one a shell step's `args.cwd` already obeyed,
+  hoisted into a shared module so there is exactly one of them: relative paths
+  join the workspace, absolute paths must resolve inside it, symlinks are
+  followed, and a missing path or a non-directory fails the step instead of
+  falling back to the workspace. A run with no workspace resolves nothing and
+  passes the value to the harness verbatim, as before.
+
 ### Changed
 
 - **Approval provenance is preserved across a resume.** `RunInput::approvals`
@@ -57,6 +70,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unaddressed `{"approved": true}` is ignored rather than settling whichever
   review reads it, since one resume value is delivered to every interrupted
   node.
+
+- **A directory key a node does not read is now a validation error.** `workdir`,
+  `working_directory`, `workspace` and friends on an `agent` node — or a
+  top-level `cwd` on a `tool_call` node, whose working directory belongs in
+  `args.cwd` — used to be accepted, persisted, and silently ignored, leaving the
+  step running in the workspace with nothing anywhere saying so. The message
+  names the key the node actually reads.
 
 - **`tinyflows::testkit` — testing, mocking, and live debugging for workflows.**
   Behind the default-off `testkit` feature; adds no dependencies.

--- a/src/caps/host/script_policy.rs
+++ b/src/caps/host/script_policy.rs
@@ -82,15 +82,6 @@ impl ScriptPolicy {
         Ok(resolved)
     }
 
-    /// The workspace root as a plain string, for a caller seeding a run's
-    /// `run.workspace` from the same policy a shell step resolves against.
-    #[must_use]
-    pub fn workspace_str(&self) -> Option<String> {
-        self.workspace
-            .as_deref()
-            .map(|w| w.to_string_lossy().into_owned())
-    }
-
     /// The shared resolution: reject the shape, then reject the destination.
     ///
     /// Delegated to [`crate::workdir`], which is where that rule now lives so

--- a/src/caps/host/script_policy.rs
+++ b/src/caps/host/script_policy.rs
@@ -16,9 +16,10 @@
 //! has no sandbox, which is exactly what `workflows.allowCode` says.
 
 use std::collections::BTreeMap;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use crate::error::{EngineError, Result};
+use crate::workdir::Absolute;
 
 /// Where a script step may read a script from and run.
 #[derive(Debug, Clone, Default)]
@@ -79,6 +80,15 @@ impl ScriptPolicy {
             )));
         }
         Ok(resolved)
+    }
+
+    /// The workspace root as a plain string, for a caller seeding a run's
+    /// `run.workspace` from the same policy a shell step resolves against.
+    #[must_use]
+    pub fn workspace_str(&self) -> Option<String> {
+        self.workspace
+            .as_deref()
+            .map(|w| w.to_string_lossy().into_owned())
     }
 
     /// The shared resolution: reject the shape, then reject the destination.

--- a/src/caps/host/script_policy.rs
+++ b/src/caps/host/script_policy.rs
@@ -83,10 +83,11 @@ impl ScriptPolicy {
 
     /// The shared resolution: reject the shape, then reject the destination.
     ///
-    /// Both halves are load-bearing. The syntactic check answers the obvious
-    /// `../../etc/passwd` without touching the disk; canonicalizing and
-    /// re-checking afterwards is what catches a symlink *inside* the workspace
-    /// pointing out of it, which no amount of string inspection would have seen.
+    /// Delegated to [`crate::workdir`], which is where that rule now lives so
+    /// the `agent` and `sub_workflow` nodes enforce the same one. A script step
+    /// keeps the stricter half of it — [`Absolute::Refuse`] — because an
+    /// operator's `args.script_path` has always been a workspace-relative name
+    /// and nothing should start reading absolute ones.
     fn resolve(&self, raw: &str, field: &str) -> Result<PathBuf> {
         let Some(workspace) = &self.workspace else {
             return Err(refused(format!(
@@ -95,40 +96,13 @@ impl ScriptPolicy {
             )));
         };
 
-        let candidate = Path::new(raw);
-        if candidate.is_absolute() {
-            return Err(refused(format!(
-                "`args.{field}` ('{raw}') must be relative to the workspace, not absolute"
-            )));
-        }
-        if candidate.components().any(|component| {
-            matches!(
-                component,
-                Component::ParentDir | Component::RootDir | Component::Prefix(_)
-            )
-        }) {
-            return Err(refused(format!(
-                "`args.{field}` ('{raw}') must not traverse outside the workspace"
-            )));
-        }
-
-        let workspace = workspace.canonicalize().map_err(|err| {
-            refused(format!(
-                "the configured workspace ({}) is unreadable: {err}",
-                workspace.display()
-            ))
-        })?;
-        let resolved = workspace.join(candidate).canonicalize().map_err(|err| {
-            refused(format!(
-                "`args.{field}` ('{raw}') does not resolve inside the workspace: {err}"
-            ))
-        })?;
-        if !resolved.starts_with(&workspace) {
-            return Err(refused(format!(
-                "`args.{field}` ('{raw}') resolves outside the workspace"
-            )));
-        }
-        Ok(resolved)
+        crate::workdir::resolve_in_workspace(
+            workspace,
+            raw,
+            &format!("args.{field}"),
+            Absolute::Refuse,
+        )
+        .map_err(refused)
     }
 }
 

--- a/src/catalog/contracts/group_01.rs
+++ b/src/catalog/contracts/group_01.rs
@@ -68,6 +68,15 @@ pub(super) fn contract_trigger() -> NodeKindContract {
                      Declared on the ROOT graph's trigger; it is forwarded to every child run, so \
                      setting it on a nested workflow has no effect.",
             ),
+            ConfigField::optional(
+                "workspace",
+                "string",
+                "The directory this run is pinned to. Every node `cwd` resolves against it \
+                     and none may escape it; a `sub_workflow` node may re-pin a child run to a \
+                     directory INSIDE it. A host that pins a workspace per run rather than per \
+                     graph puts the same key on the trigger PAYLOAD instead. With no workspace \
+                     the engine resolves nothing and a `cwd` reaches the harness verbatim.",
+            ),
         ],
         ports: PortSpec::new(&[], &["main"]),
         example: json!({
@@ -126,11 +135,23 @@ pub(super) fn contract_agent() -> NodeKindContract {
                      providers need not parse a composite string.",
             ),
             ConfigField::optional(
-                "working_dir",
+                "cwd",
                 "string",
                 "Working directory the agent runs in, when it runs somewhere with a \
-                     filesystem. Opaque and UNTRUSTED: the engine never touches the filesystem, \
-                     so the host must validate it against its own permitted roots.",
+                     filesystem. Resolved against the run's workspace (trigger config.workspace): \
+                     a relative path is joined to it, an absolute one must resolve inside it, and \
+                     a directory that is missing or is not a directory FAILS the step rather than \
+                     falling back to the workspace. Bindable, which is the point — \
+                     \"=nodes.prepare.item.json.worktree\" points the step at a directory an \
+                     earlier node created. On a run with no workspace the string is passed to the \
+                     harness verbatim and the host must validate it itself.",
+            ),
+            ConfigField::optional(
+                "working_dir",
+                "string",
+                "The older spelling of `cwd`, and the name of the field on an agent \
+                     definition, so it stays accepted; `cwd` wins when both are set. Same \
+                     resolution rules.",
             ),
             ConfigField::optional(
                 "context",
@@ -199,7 +220,7 @@ pub(super) fn contract_agent() -> NodeKindContract {
                 .to_string(),
             "Merge order is definition-then-node, narrowing only: instructions append, \
                  context appends, tools intersect, limits take the lower bound, metadata merges \
-                 per key, and model/provider/working_dir are overridden by the node."
+                 per key, and model/provider/cwd (working_dir) are overridden by the node."
                 .to_string(),
             "agent_ref, tool slug, tool connection_ref, a memory context scope, and a host \
                  context source must all be LITERALS, never =expressions — otherwise run data \

--- a/src/catalog/contracts/group_02.rs
+++ b/src/catalog/contracts/group_02.rs
@@ -177,6 +177,15 @@ pub(super) fn contract_sub_workflow() -> NodeKindContract {
                 "The id of a saved workflow to run as the child. Provide this OR workflow.",
             ),
             ConfigField::optional(
+                "workspace",
+                "string",
+                "Runs the child in another directory: it becomes the CHILD run's workspace, \
+                     which the child's own nodes resolve their `cwd` against. Resolved against \
+                     the parent's workspace under the same rule as an agent node's `cwd` (must \
+                     resolve inside it, must exist, must be a directory) and bindable the same \
+                     way. Omitted, the child inherits the parent's workspace.",
+            ),
+            ConfigField::optional(
                 "inputs",
                 "object",
                 "Values for the child's declared workflow inputs, by name. Each value is \

--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -149,8 +149,21 @@ pub(crate) async fn run_sub_workflow(
     depth: u64,
     max_depth: u64,
     token: CancellationToken,
+    workspace: Option<String>,
 ) -> Result<RunOutcome> {
     let observer: Arc<dyn RunObserver> = Arc::new(crate::observability::NoopObserver);
+    let mut overlay = json!({
+        "sub_workflow_depth": depth,
+        "max_sub_workflow_depth": max_depth,
+    });
+    // The child's workspace: the parent's, unless the `sub_workflow` node named
+    // another (already resolved and contained by the node). Inherited rather
+    // than dropped, because a child whose agents suddenly resolved their `cwd`
+    // against nothing would run them in whatever directory the harness defaults
+    // to — the silent relocation this whole seam exists to prevent.
+    if let Some(workspace) = workspace {
+        overlay["workspace"] = Value::from(workspace);
+    }
     let (_graph, _thread_id, outcome, _run_ids) = build_and_run(
         workflow,
         input,
@@ -158,10 +171,7 @@ pub(crate) async fn run_sub_workflow(
         &observer,
         RunConfig::new(workflow)?
             .with_token(token)
-            .with_overlay(json!({
-                "sub_workflow_depth": depth,
-                "max_sub_workflow_depth": max_depth,
-            })),
+            .with_overlay(overlay),
     )
     .await?;
     Ok(outcome)

--- a/src/engine/run_state.rs
+++ b/src/engine/run_state.rs
@@ -154,6 +154,22 @@ pub(super) async fn build_and_run(
             json!({ "run": { "max_sub_workflow_depth": max_depth } }),
         );
     }
+    // The run's workspace: the directory an author-supplied `cwd` resolves
+    // against and may not escape (see `crate::workdir`). Read off the trigger
+    // config like every other run-level knob and seeded into the run state, so
+    // a node reads it back without knowing anything about the graph. A host that
+    // pins a workspace per run rather than per graph puts a `workspace` key on
+    // the trigger payload instead; both are read by `workdir::run_workspace`.
+    if let Some(workspace) = workflow
+        .graph
+        .trigger()
+        .and_then(|t| t.config.get("workspace"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|w| !w.is_empty())
+    {
+        merge(&mut initial, json!({ "run": { "workspace": workspace } }));
+    }
     // Optional run-level metadata overlaid onto `run` before the run starts —
     // e.g. the `sub_workflow_depth` counter a nested `sub_workflow` run threads
     // to bound recursion (see [`run_sub_workflow`]). Merged (not overwritten) so

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,10 @@ pub mod store;
 #[cfg(any(test, feature = "testkit"))]
 pub mod testkit;
 pub mod validate;
+// Resolving an author-supplied working directory against the run's workspace —
+// the containment rule a shell step's `args.cwd` already obeyed, shared with the
+// `agent` and `sub_workflow` nodes so there is exactly one of them.
+mod workdir;
 /// Render workflow structure to PNG or JPEG files for visual debugging.
 #[cfg(feature = "graph-debug")]
 pub mod visualization;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,10 @@ pub mod validate;
 // Resolving an author-supplied working directory against the run's workspace —
 // the containment rule a shell step's `args.cwd` already obeyed, shared with the
 // `agent` and `sub_workflow` nodes so there is exactly one of them.
-mod workdir;
 /// Render workflow structure to PNG or JPEG files for visual debugging.
 #[cfg(feature = "graph-debug")]
 pub mod visualization;
+mod workdir;
 
 /// The crate name published to crates.io.
 pub const CRATE_NAME: &str = env!("CARGO_PKG_NAME");

--- a/src/nodes/integration/agent.rs
+++ b/src/nodes/integration/agent.rs
@@ -159,7 +159,7 @@ async fn run_turn_indexed(
     // context still reaches the model on a host with no `AgentRunner`. Nodes
     // that declare no context are untouched, so an existing graph's request is
     // byte-identical to what it has always been.
-    let request = match cfg.get("context") {
+    let mut request = match cfg.get("context") {
         Some(raw) if !raw.is_null() => {
             let sources: Vec<crate::model::ContextSource> = serde_json::from_value(raw.clone())
                 .map_err(|e| {
@@ -176,6 +176,25 @@ async fn run_turn_indexed(
         }
         _ => cfg.clone(),
     };
+    // A declared working directory is checked on this path too. The bare
+    // completion has nowhere to *run*, so the resolved value is only normalised
+    // into the request for a provider that forwards it — but an author who
+    // pointed a step at a directory that escapes the workspace or is not there
+    // is told so here rather than discovering it the next time a harness is
+    // wired. Both spellings are set to the resolved path so a provider reading
+    // either sees the same directory.
+    if let Some(raw) = super::agent_request::declared_working_dir(cfg, &ctx.node.id)? {
+        let key = if cfg.get("cwd").is_some() {
+            "cwd"
+        } else {
+            "working_dir"
+        };
+        let resolved = super::agent_request::resolve_working_dir(ctx, &raw, key)?;
+        if let Value::Object(map) = &mut request {
+            map.insert("cwd".to_string(), Value::from(resolved.clone()));
+            map.insert("working_dir".to_string(), Value::from(resolved));
+        }
+    }
     let response = ctx.caps.llm.complete(request, conn).await?;
 
     // `text`/`raw` are derived from the untouched completion; `value` is the

--- a/src/nodes/integration/agent_request.rs
+++ b/src/nodes/integration/agent_request.rs
@@ -95,7 +95,7 @@ pub(crate) async fn resolve_definition(
 /// | field | rule |
 /// |---|---|
 /// | `instructions` | the node's are **appended** to the definition's, never replacing them — a node must not be able to silently neuter a curated agent's standing instructions |
-/// | `model`, `provider`, `working_dir` | the node's win when set |
+/// | `model`, `provider`, `cwd`/`working_dir` | the node's win when set |
 /// | `context` | the definition's blocks first, then the node's |
 /// | `tools` | when the definition grants any, the node's list **intersects** them and may not add a tool the definition never granted; when the definition grants none there is nothing to narrow against, so the node's stand |
 /// | `limits` | field-wise, keeping the **lower** of each declared bound |
@@ -125,8 +125,8 @@ pub(crate) fn merge_node_overrides(
     if let Some(provider) = cfg.get("provider").and_then(Value::as_str) {
         definition.provider = Some(provider.to_string());
     }
-    if let Some(working_dir) = cfg.get("working_dir").and_then(Value::as_str) {
-        definition.working_dir = Some(working_dir.to_string());
+    if let Some(working_dir) = declared_working_dir(cfg, node_id)? {
+        definition.working_dir = Some(working_dir);
     }
 
     let node_context: Vec<ContextSource> = field(cfg, "context", node_id)?;
@@ -180,6 +180,62 @@ fn narrow_tools(granted: &[ToolGrant], requested: &[ToolGrant], node_id: &str) -
         })
         .cloned()
         .collect()
+}
+
+/// The working directory a node declared, under either spelling.
+///
+/// `cwd` is the name every other surface in the crate uses for "run this step
+/// over there" — a `shell` node's `config.cwd`, a script step's `args.cwd` — so
+/// it is the one to reach for. `working_dir` is the older spelling, and the name
+/// of the field on [`AgentDefinition`], so it stays accepted; `cwd` wins when
+/// both are set.
+///
+/// # Errors
+/// Refuses a non-string or a blank value, exactly as a `shell` node's `cwd`
+/// does. A number or an empty string here is an authoring slip, and the
+/// alternative is a step that silently runs somewhere else.
+pub(crate) fn declared_working_dir(cfg: &Value, node_id: &str) -> Result<Option<String>> {
+    for key in ["cwd", "working_dir"] {
+        let Some(value) = cfg.get(key).filter(|v| !v.is_null()) else {
+            continue;
+        };
+        let dir = value.as_str().ok_or_else(|| {
+            EngineError::Capability(format!("agent node {node_id}: `{key}` must be a string"))
+        })?;
+        if dir.trim().is_empty() {
+            return Err(EngineError::Capability(format!(
+                "agent node {node_id}: `{key}` must be a non-empty path when present"
+            )));
+        }
+        return Ok(Some(dir.to_string()));
+    }
+    Ok(None)
+}
+
+/// Resolves a declared working directory against the run's workspace.
+///
+/// The value is already expression-resolved by the node's config pass, which is
+/// the point: the directory an `agent` node runs in is usually one an earlier
+/// node just created, addressed as `"=nodes.prepare.item.json.worktree"`.
+///
+/// On a run with no workspace the string passes through untouched — see
+/// [`crate::workdir`] for why the engine will not check a filesystem the agent
+/// may not even be running on.
+///
+/// # Errors
+/// Returns [`EngineError::Capability`] when the directory escapes the
+/// workspace, does not exist, or is not a directory.
+pub(crate) fn resolve_working_dir(
+    ctx: &NodeContext<'_>,
+    raw: &str,
+    key: &str,
+) -> Result<String> {
+    crate::workdir::resolve_node_dir(
+        ctx.run,
+        raw,
+        &format!("config.{key}"),
+        &format!("agent node {}", ctx.node.id),
+    )
 }
 
 /// Resolves each declared [`ContextSource`] into a [`ContextBlock`], in
@@ -338,7 +394,18 @@ pub(crate) async fn assemble(
         })?
     };
 
-    let agent = merge_node_overrides(definition, cfg, &ctx.node.id)?;
+    let mut agent = merge_node_overrides(definition, cfg, &ctx.node.id)?;
+    // The effective working directory, resolved against the run's workspace and
+    // refused if it escapes it. Done on the merged value so a definition's own
+    // `working_dir` is held to the same rule as a node's `cwd`.
+    if let Some(raw) = agent.working_dir.clone() {
+        let key = if cfg.get("cwd").is_some() {
+            "cwd"
+        } else {
+            "working_dir"
+        };
+        agent.working_dir = Some(resolve_working_dir(ctx, &raw, key)?);
+    }
     let identity = identity_of(ctx, item_index);
     let conn = cfg.get("connection_ref").and_then(Value::as_str);
 

--- a/src/nodes/integration/agent_request.rs
+++ b/src/nodes/integration/agent_request.rs
@@ -225,11 +225,7 @@ pub(crate) fn declared_working_dir(cfg: &Value, node_id: &str) -> Result<Option<
 /// # Errors
 /// Returns [`EngineError::Capability`] when the directory escapes the
 /// workspace, does not exist, or is not a directory.
-pub(crate) fn resolve_working_dir(
-    ctx: &NodeContext<'_>,
-    raw: &str,
-    key: &str,
-) -> Result<String> {
+pub(crate) fn resolve_working_dir(ctx: &NodeContext<'_>, raw: &str, key: &str) -> Result<String> {
     crate::workdir::resolve_node_dir(
         ctx.run,
         raw,

--- a/src/nodes/integration/sub_workflow/execution.rs
+++ b/src/nodes/integration/sub_workflow/execution.rs
@@ -118,6 +118,39 @@ fn pause_for_child_gates(node_id: &str, gates: Vec<String>) -> NodeOutput {
     )
 }
 
+/// The workspace the child run is pinned to: this node's `workspace` override
+/// when it declares one, else the parent's.
+///
+/// The override is resolved against the parent's workspace and refused if it
+/// escapes it — the same rule, and the same code, as an `agent` node's `cwd`
+/// (see [`crate::workdir`]). A parent run with no workspace has nothing to
+/// contain the value against, so it is taken as written: that is how a graph
+/// declares a workspace for a child when the run itself was never pinned to one.
+fn child_workspace(ctx: &NodeContext<'_>, scope: &Value) -> Result<Option<String>> {
+    let Some(declared) = ctx.node.config.get("workspace").filter(|v| !v.is_null()) else {
+        return Ok(crate::workdir::run_workspace(ctx.run).map(str::to_string));
+    };
+    let declared = crate::expr::resolve(declared, scope);
+    let raw = declared.as_str().ok_or_else(|| {
+        EngineError::Capability(format!(
+            "sub_workflow node {}: `workspace` must be a string",
+            ctx.node.id
+        ))
+    })?;
+    if raw.trim().is_empty() {
+        return Err(EngineError::Capability(format!(
+            "sub_workflow node {}: `workspace` must be a non-empty path when present",
+            ctx.node.id
+        )));
+    }
+    Ok(Some(crate::workdir::resolve_node_dir(
+        ctx.run,
+        raw,
+        "config.workspace",
+        &format!("sub_workflow node {}", ctx.node.id),
+    )?))
+}
+
 /// What one child run produced, from the parent node's point of view.
 ///
 /// Three outcomes rather than two: a child can finish, wind down because the
@@ -221,6 +254,12 @@ async fn run_child(
     // from the batch — the whole point of resolving inputs in here rather than
     // once at the call site.
     let child_inputs = child_inputs(&ctx.node.config, scope)?;
+    // Where the child runs. `config.workspace` (expression-resolved like
+    // `workflow_id`, so it can name a directory an earlier node created) becomes
+    // the child run's workspace, held to the same containment rule as an
+    // `agent` node's `cwd`: it must resolve inside the parent's workspace. With
+    // no override the child inherits the parent's.
+    let child_workspace = child_workspace(ctx, scope)?;
     // Box the recursive engine call so the async future type stays sized.
     // Forward the parent run's cancellation token: cancelling the parent must
     // wind down this child too, rather than letting it run on orphaned behind a
@@ -235,6 +274,7 @@ async fn run_child(
         child_depth,
         depth_cap,
         ctx.token.clone(),
+        child_workspace,
     ))
     .await?;
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -537,6 +537,7 @@ pub fn validate_all(graph: &WorkflowGraph) -> Vec<ValidationError> {
 
     validate_loops(graph, &mut errors);
     validate_scatter_regions(graph, &mut errors);
+    validate_working_dirs(graph, &mut errors);
     // Declared-input checks. These are author-time mistakes that would otherwise
     // surface as a confusing runtime `null`: a name that `=inputs.<name>` cannot
     // address, two declarations racing for the same key, a default the input's
@@ -580,6 +581,9 @@ use loops::validate_loops;
 
 mod scatter;
 use scatter::{nodes_on_cycle, path_exists, validate_scatter_regions};
+
+mod workdir;
+use workdir::validate_working_dirs;
 
 #[cfg(test)]
 #[path = "validate_tests.rs"]

--- a/src/validate/workdir.rs
+++ b/src/validate/workdir.rs
@@ -42,9 +42,7 @@ fn advice(kind: &NodeKind, key: &str) -> String {
         NodeKind::SubWorkflow => {
             format!("use `workspace` to re-pin the child run's workspace, not `{key}`")
         }
-        NodeKind::Trigger => format!(
-            "use `workspace` to pin the run's workspace, not `{key}`"
-        ),
+        NodeKind::Trigger => format!("use `workspace` to pin the run's workspace, not `{key}`"),
         NodeKind::ToolCall => format!(
             "a tool's working directory goes in `args.cwd`, which the tool itself reads — a \
              top-level `{key}` on the node is never looked at"

--- a/src/validate/workdir.rs
+++ b/src/validate/workdir.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+/// Every spelling an author reaches for when they mean "run this step over
+/// there".
+///
+/// The list is deliberately wide. The failure this check exists to stop is not
+/// a typo — it is a plausible key that the engine accepts, persists, validates
+/// cleanly, and then ignores, leaving the step running in the run's workspace
+/// with nothing anywhere saying otherwise.
+const DIRECTORY_KEYS: [&str; 7] = [
+    "cwd",
+    "workdir",
+    "work_dir",
+    "working_dir",
+    "working_directory",
+    "workspace",
+    "directory",
+];
+
+/// The directory keys a node of `kind` actually reads at run time.
+fn honored_by(kind: &NodeKind) -> &'static [&'static str] {
+    match kind {
+        // `cwd` is the spelling to reach for; `working_dir` is the older one
+        // and the name of the field on `AgentDefinition`, so it stays accepted.
+        NodeKind::Agent => &["cwd", "working_dir"],
+        NodeKind::Shell => &["cwd"],
+        // Not a process working directory: it re-pins the *child run's*
+        // workspace, which is what the directories inside it resolve against.
+        NodeKind::SubWorkflow => &["workspace"],
+        // The run-level knob every `cwd` in the graph resolves against.
+        NodeKind::Trigger => &["workspace"],
+        _ => &[],
+    }
+}
+
+/// What to tell an author who put a directory key where it does nothing.
+fn advice(kind: &NodeKind, key: &str) -> String {
+    match kind {
+        NodeKind::Agent | NodeKind::Shell => {
+            format!("use `cwd` (this node reads `cwd`, not `{key}`)")
+        }
+        NodeKind::SubWorkflow => {
+            format!("use `workspace` to re-pin the child run's workspace, not `{key}`")
+        }
+        NodeKind::Trigger => format!(
+            "use `workspace` to pin the run's workspace, not `{key}`"
+        ),
+        NodeKind::ToolCall => format!(
+            "a tool's working directory goes in `args.cwd`, which the tool itself reads — a \
+             top-level `{key}` on the node is never looked at"
+        ),
+        _ => format!(
+            "a {} node has no working directory; put the step that needs one in an `agent` or \
+             `shell` node, or re-pin the workspace on the `sub_workflow` node that runs it",
+            kind_name(kind)
+        ),
+    }
+}
+
+/// Directory keys that would be silently ignored where they were written.
+///
+/// A node's `config` is free-form JSON: an unrecognised key is not a
+/// deserialization error, it is simply never read. For most keys that is
+/// harmless. For this family it is the worst failure the engine can produce —
+/// the author has said *where* the work happens, the graph validates, the run
+/// goes green, and the work happened somewhere else. When that somewhere else
+/// is the primary checkout of a repository rather than the worktree the author
+/// prepared, anything the step commits lands on the wrong branch.
+///
+/// Refused rather than warned, matching how this crate already treats a config
+/// key that cannot do what it says (`concurrency` without `per_item`, an
+/// unknown `execution`). Nothing is taken away from a graph that worked: a key
+/// named here was, by construction, doing nothing.
+pub(super) fn validate_working_dirs(graph: &WorkflowGraph, errors: &mut Vec<ValidationError>) {
+    for node in &graph.nodes {
+        let honored = honored_by(&node.kind);
+        for key in DIRECTORY_KEYS {
+            if honored.contains(&key) || node.config.get(key).is_none() {
+                continue;
+            }
+            errors.push(ValidationError::InvalidNodeConfig {
+                node: node.id.clone(),
+                reason: format!(
+                    "`{key}` is not read by a {} node and would be silently ignored — the step \
+                     would run in the run's workspace instead: {}",
+                    kind_name(&node.kind),
+                    advice(&node.kind, key)
+                ),
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "workdir_tests.rs"]
+mod tests;

--- a/src/validate/workdir_tests.rs
+++ b/src/validate/workdir_tests.rs
@@ -1,0 +1,112 @@
+//! Tests for the working-directory config check: a key that names where a step
+//! runs must be one the node actually reads.
+
+use serde_json::json;
+
+use crate::model::WorkflowGraph;
+use crate::validate::validate_all;
+
+/// A one-node graph whose single non-trigger node carries `config`.
+fn graph_with(kind: &str, config: serde_json::Value) -> WorkflowGraph {
+    serde_json::from_value(json!({
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "start", "config": { "trigger_kind": "manual" } },
+            { "id": "step", "kind": kind, "name": "step", "config": config }
+        ],
+        "edges": [{ "from_node": "t", "to_node": "step" }]
+    }))
+    .expect("graph deserializes")
+}
+
+/// The reasons `validate_all` reported, joined for substring assertions.
+fn reasons(graph: &WorkflowGraph) -> String {
+    validate_all(graph)
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn an_agent_node_may_name_its_working_directory() {
+    for key in ["cwd", "working_dir"] {
+        let graph = graph_with("agent", json!({ "prompt": "go", key: "worktrees/issue-1" }));
+        assert!(
+            validate_all(&graph).is_empty(),
+            "`{key}` is read by an agent node"
+        );
+    }
+}
+
+#[test]
+fn a_directory_key_an_agent_node_never_reads_is_refused() {
+    // The failure this check exists for: the key is accepted, persisted, and
+    // then ignored, so the step runs in the workspace with nothing saying so.
+    for key in ["workdir", "work_dir", "working_directory", "workspace", "directory"] {
+        let graph = graph_with("agent", json!({ "prompt": "go", key: "/srv/elsewhere" }));
+        let reasons = reasons(&graph);
+        assert!(reasons.contains(key), "`{key}` should be refused: {reasons}");
+        assert!(reasons.contains("use `cwd`"), "{reasons}");
+    }
+}
+
+#[test]
+fn a_tool_call_node_is_pointed_at_args_cwd() {
+    let graph = graph_with("tool_call", json!({ "slug": "shell.run", "cwd": "build" }));
+    let reasons = reasons(&graph);
+
+    assert!(reasons.contains("`args.cwd`"), "{reasons}");
+}
+
+#[test]
+fn a_sub_workflow_node_may_re_pin_the_child_workspace() {
+    let graph = graph_with(
+        "sub_workflow",
+        json!({ "workflow_id": "child", "workspace": "worktrees/issue-1" }),
+    );
+
+    assert!(validate_all(&graph).is_empty());
+}
+
+#[test]
+fn a_sub_workflow_node_naming_cwd_is_told_the_right_key() {
+    let graph = graph_with(
+        "sub_workflow",
+        json!({ "workflow_id": "child", "cwd": "worktrees/issue-1" }),
+    );
+    let reasons = reasons(&graph);
+
+    assert!(reasons.contains("use `workspace`"), "{reasons}");
+}
+
+#[test]
+fn a_trigger_may_pin_the_runs_workspace() {
+    let graph: WorkflowGraph = serde_json::from_value(json!({
+        "nodes": [{
+            "id": "t", "kind": "trigger", "name": "start",
+            "config": { "trigger_kind": "manual", "workspace": "/srv/checkout" }
+        }],
+        "edges": []
+    }))
+    .expect("graph deserializes");
+
+    assert!(validate_all(&graph).is_empty());
+}
+
+#[test]
+fn a_node_kind_with_no_working_directory_says_so() {
+    let graph = graph_with("transform", json!({ "expression": "=item", "cwd": "build" }));
+    let reasons = reasons(&graph);
+
+    assert!(
+        reasons.contains("has no working directory"),
+        "{reasons}"
+    );
+}
+
+#[test]
+fn a_shell_node_keeps_reading_cwd() {
+    let graph = graph_with("shell", json!({ "source": "pwd", "cwd": "build" }));
+
+    assert!(validate_all(&graph).is_empty());
+}

--- a/src/validate/workdir_tests.rs
+++ b/src/validate/workdir_tests.rs
@@ -42,10 +42,19 @@ fn an_agent_node_may_name_its_working_directory() {
 fn a_directory_key_an_agent_node_never_reads_is_refused() {
     // The failure this check exists for: the key is accepted, persisted, and
     // then ignored, so the step runs in the workspace with nothing saying so.
-    for key in ["workdir", "work_dir", "working_directory", "workspace", "directory"] {
+    for key in [
+        "workdir",
+        "work_dir",
+        "working_directory",
+        "workspace",
+        "directory",
+    ] {
         let graph = graph_with("agent", json!({ "prompt": "go", key: "/srv/elsewhere" }));
         let reasons = reasons(&graph);
-        assert!(reasons.contains(key), "`{key}` should be refused: {reasons}");
+        assert!(
+            reasons.contains(key),
+            "`{key}` should be refused: {reasons}"
+        );
         assert!(reasons.contains("use `cwd`"), "{reasons}");
     }
 }
@@ -95,13 +104,13 @@ fn a_trigger_may_pin_the_runs_workspace() {
 
 #[test]
 fn a_node_kind_with_no_working_directory_says_so() {
-    let graph = graph_with("transform", json!({ "expression": "=item", "cwd": "build" }));
+    let graph = graph_with(
+        "transform",
+        json!({ "expression": "=item", "cwd": "build" }),
+    );
     let reasons = reasons(&graph);
 
-    assert!(
-        reasons.contains("has no working directory"),
-        "{reasons}"
-    );
+    assert!(reasons.contains("has no working directory"), "{reasons}");
 }
 
 #[test]

--- a/src/workdir.rs
+++ b/src/workdir.rs
@@ -175,13 +175,10 @@ pub(crate) fn resolve_node_dir(
         );
         return Ok(raw.to_string());
     };
-    let resolved = resolve_dir_in_workspace(
-        Path::new(workspace),
-        raw,
-        field,
-        Absolute::AllowInside,
-    )
-    .map_err(|message| crate::error::EngineError::Capability(format!("{surface}: {message}")))?;
+    let resolved =
+        resolve_dir_in_workspace(Path::new(workspace), raw, field, Absolute::AllowInside).map_err(
+            |message| crate::error::EngineError::Capability(format!("{surface}: {message}")),
+        )?;
     Ok(resolved.to_string_lossy().into_owned())
 }
 

--- a/src/workdir.rs
+++ b/src/workdir.rs
@@ -1,0 +1,190 @@
+//! Resolving an author-supplied working directory against the run's workspace.
+//!
+//! A node config's `cwd` (and a `sub_workflow` node's `workspace`) is an
+//! **untrusted string**: a workflow arrives as a file, possibly written by an
+//! agent, and the directory it names is where a harness will run. The rule this
+//! module holds is the one
+//! [`ScriptPolicy`](crate::caps::host::ScriptPolicy) already held for a shell
+//! step's `args.cwd` — resolve against the configured workspace, follow
+//! symlinks, and refuse anything that lands outside it — hoisted here so the
+//! `agent` and `sub_workflow` nodes enforce the *same* rule rather than a second
+//! one shaped slightly differently.
+//!
+//! # The workspace
+//!
+//! The engine has no filesystem of its own, so the boundary has to be declared.
+//! A run carries it at `run.workspace`, seeded from the trigger node's
+//! `config.workspace` (graph-level) or from the trigger payload's `workspace`
+//! key (per-run, host-supplied), and forwarded to `sub_workflow` children.
+//!
+//! **A run with no workspace resolves nothing.** A `cwd` on such a run is passed
+//! through to the harness verbatim, exactly as `working_dir` always has been:
+//! a host whose agents run in a remote sandbox names directories the engine's
+//! own filesystem knows nothing about, and checking those against the local disk
+//! would fail every one of them.
+
+use std::path::{Component, Path, PathBuf};
+
+use serde_json::Value;
+
+/// Whether an author may name an absolute path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Absolute {
+    /// Refuse one outright — the historical `args.script_path` / `args.cwd`
+    /// rule, where a relative path is the only legal spelling.
+    Refuse,
+    /// Accept one, provided it resolves inside the workspace.
+    ///
+    /// What an `agent` node's `cwd` needs: the directory it points at is
+    /// usually one an earlier node created and reported back as an absolute
+    /// path (`"=nodes.prepare.item.json.worktree"`), and demanding the author
+    /// re-derive a relative path from it would be busywork with a worse failure
+    /// mode.
+    AllowInside,
+}
+
+/// The workspace this run is pinned to, if any.
+///
+/// Precedence: the seeded `run.workspace`, then a `workspace` key on the
+/// trigger payload (`run.trigger.workspace`) for a host that pins one per run
+/// without editing the graph.
+#[must_use]
+pub(crate) fn run_workspace(run: &Value) -> Option<&str> {
+    run.get("workspace")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            run.get("trigger")
+                .and_then(|t| t.get("workspace"))
+                .and_then(Value::as_str)
+        })
+        .map(str::trim)
+        .filter(|w| !w.is_empty())
+}
+
+/// Resolves `raw` against `workspace`, refusing anything that escapes it.
+///
+/// Both halves are load-bearing, and both come from the shell step's policy.
+/// The syntactic check answers the obvious `../../etc/passwd` without touching
+/// the disk; canonicalizing and re-checking afterwards is what catches a symlink
+/// *inside* the workspace pointing out of it, which no amount of string
+/// inspection would have seen.
+///
+/// `field` is how the caller spells the offending key (`args.cwd`,
+/// `config.cwd`), so the message points at what the author wrote. The error is
+/// a bare message: each caller wraps it in its own surface's error prefix.
+///
+/// # Errors
+/// Returns the refusal message when the workspace is unreadable, when `raw` is
+/// shaped wrong for `absolute`, when it traverses upwards, or when it does not
+/// resolve to an existing path inside the workspace.
+pub(crate) fn resolve_in_workspace(
+    workspace: &Path,
+    raw: &str,
+    field: &str,
+    absolute: Absolute,
+) -> Result<PathBuf, String> {
+    let candidate = Path::new(raw);
+    if candidate.is_absolute() {
+        if absolute == Absolute::Refuse {
+            return Err(format!(
+                "`{field}` ('{raw}') must be relative to the workspace, not absolute"
+            ));
+        }
+    } else if candidate.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return Err(format!(
+            "`{field}` ('{raw}') must not traverse outside the workspace"
+        ));
+    }
+
+    let workspace = workspace.canonicalize().map_err(|err| {
+        format!(
+            "the configured workspace ({}) is unreadable: {err}",
+            workspace.display()
+        )
+    })?;
+    let joined = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        workspace.join(candidate)
+    };
+    let resolved = joined.canonicalize().map_err(|err| {
+        format!(
+            "`{field}` ('{raw}') does not resolve inside the workspace ({}): {err}",
+            joined.display()
+        )
+    })?;
+    if !resolved.starts_with(&workspace) {
+        return Err(format!(
+            "`{field}` ('{raw}') resolves outside the workspace ({})",
+            workspace.display()
+        ));
+    }
+    Ok(resolved)
+}
+
+/// [`resolve_in_workspace`], additionally requiring the result to be a
+/// directory.
+///
+/// # Errors
+/// As [`resolve_in_workspace`], plus a refusal when the path exists but is not a
+/// directory. A path that does not exist at all fails in
+/// [`resolve_in_workspace`] rather than falling back to the workspace: a step
+/// silently running somewhere other than where its author said is the failure
+/// this whole module exists to prevent.
+pub(crate) fn resolve_dir_in_workspace(
+    workspace: &Path,
+    raw: &str,
+    field: &str,
+    absolute: Absolute,
+) -> Result<PathBuf, String> {
+    let resolved = resolve_in_workspace(workspace, raw, field, absolute)?;
+    if !resolved.is_dir() {
+        return Err(format!(
+            "`{field}` ('{raw}') is not a directory in the workspace"
+        ));
+    }
+    Ok(resolved)
+}
+
+/// Resolves a node's declared working directory against the run's workspace.
+///
+/// Returns the resolved absolute path when the run is pinned to a workspace, and
+/// `raw` unchanged when it is not (see the module docs: the engine cannot check
+/// a directory on a filesystem it does not have).
+///
+/// # Errors
+/// Returns [`EngineError::Capability`](crate::error::EngineError::Capability),
+/// prefixed with `surface`, when the directory escapes the workspace, does not
+/// exist, or is not a directory.
+pub(crate) fn resolve_node_dir(
+    run: &Value,
+    raw: &str,
+    field: &str,
+    surface: &str,
+) -> crate::error::Result<String> {
+    let Some(workspace) = run_workspace(run) else {
+        tracing::debug!(
+            field,
+            raw,
+            "workdir: the run declares no workspace; passing the directory through unresolved"
+        );
+        return Ok(raw.to_string());
+    };
+    let resolved = resolve_dir_in_workspace(
+        Path::new(workspace),
+        raw,
+        field,
+        Absolute::AllowInside,
+    )
+    .map_err(|message| crate::error::EngineError::Capability(format!("{surface}: {message}")))?;
+    Ok(resolved.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+#[path = "workdir_tests.rs"]
+mod tests;

--- a/src/workdir_tests.rs
+++ b/src/workdir_tests.rs
@@ -1,0 +1,190 @@
+//! Tests for working-directory resolution: what a node may name as the
+//! directory it runs in, and what happens to the value when the run is pinned
+//! to no workspace at all.
+//!
+//! Filesystem-only and offline — nothing here runs a graph.
+
+use serde_json::json;
+
+use super::{Absolute, resolve_dir_in_workspace, resolve_in_workspace, resolve_node_dir, run_workspace};
+
+/// A workspace with a `worktrees/issue-1` directory and a file in it.
+fn workspace() -> tempfile::TempDir {
+    let root = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(root.path().join("worktrees/issue-1")).expect("mkdir");
+    std::fs::write(root.path().join("notes.txt"), "not a directory").expect("write");
+    root
+}
+
+/// The canonical form of `root`, which is what a resolved path is compared
+/// against: a temporary directory is a symlink on some platforms.
+fn canonical(root: &tempfile::TempDir) -> std::path::PathBuf {
+    root.path().canonicalize().expect("canonicalize")
+}
+
+#[test]
+fn a_relative_directory_resolves_against_the_workspace() {
+    let root = workspace();
+    let resolved = resolve_dir_in_workspace(
+        root.path(),
+        "worktrees/issue-1",
+        "config.cwd",
+        Absolute::AllowInside,
+    )
+    .expect("a directory in the workspace resolves");
+
+    assert_eq!(resolved, canonical(&root).join("worktrees/issue-1"));
+}
+
+#[test]
+fn an_absolute_directory_inside_the_workspace_is_allowed() {
+    // The motivating case: an earlier node reports the worktree it created as
+    // an absolute path, and the next node binds `cwd` straight to it.
+    let root = workspace();
+    let inside = canonical(&root).join("worktrees/issue-1");
+    let resolved = resolve_dir_in_workspace(
+        root.path(),
+        &inside.to_string_lossy(),
+        "config.cwd",
+        Absolute::AllowInside,
+    )
+    .expect("an absolute path inside the workspace resolves");
+
+    assert_eq!(resolved, inside);
+}
+
+#[test]
+fn an_absolute_directory_is_refused_where_the_rule_is_stricter() {
+    // A script step's `args.script_path` has always been workspace-relative.
+    let root = workspace();
+    let inside = canonical(&root).join("worktrees/issue-1");
+    let error = resolve_in_workspace(
+        root.path(),
+        &inside.to_string_lossy(),
+        "args.cwd",
+        Absolute::Refuse,
+    )
+    .expect_err("Absolute::Refuse takes no absolute path, inside or not");
+
+    assert!(error.contains("must be relative to the workspace"), "{error}");
+}
+
+#[test]
+fn a_directory_outside_the_workspace_is_refused() {
+    let root = workspace();
+    let elsewhere = tempfile::tempdir().expect("tempdir");
+    let error = resolve_dir_in_workspace(
+        root.path(),
+        &elsewhere.path().to_string_lossy(),
+        "config.cwd",
+        Absolute::AllowInside,
+    )
+    .expect_err("an absolute path outside the workspace is refused");
+
+    assert!(error.contains("resolves outside the workspace"), "{error}");
+}
+
+#[test]
+fn a_relative_directory_may_not_traverse_out_of_the_workspace() {
+    let root = workspace();
+    let error = resolve_dir_in_workspace(
+        root.path(),
+        "../elsewhere",
+        "config.cwd",
+        Absolute::AllowInside,
+    )
+    .expect_err("`..` is refused before the disk is touched");
+
+    assert!(error.contains("must not traverse outside"), "{error}");
+}
+
+#[test]
+fn a_directory_that_does_not_exist_fails_naming_the_path() {
+    let root = workspace();
+    let error = resolve_dir_in_workspace(
+        root.path(),
+        "worktrees/issue-404",
+        "config.cwd",
+        Absolute::AllowInside,
+    )
+    .expect_err("a missing directory fails rather than falling back to the workspace");
+
+    assert!(error.contains("worktrees/issue-404"), "{error}");
+    assert!(error.contains("does not resolve inside the workspace"), "{error}");
+}
+
+#[test]
+fn a_path_that_is_not_a_directory_is_refused() {
+    let root = workspace();
+    let error = resolve_dir_in_workspace(
+        root.path(),
+        "notes.txt",
+        "config.cwd",
+        Absolute::AllowInside,
+    )
+    .expect_err("a file is not a working directory");
+
+    assert!(error.contains("is not a directory"), "{error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn a_symlink_inside_the_workspace_pointing_out_of_it_is_refused() {
+    // The half no amount of string inspection would have caught.
+    let root = workspace();
+    let elsewhere = tempfile::tempdir().expect("tempdir");
+    std::os::unix::fs::symlink(elsewhere.path(), root.path().join("escape")).expect("symlink");
+
+    let error = resolve_dir_in_workspace(
+        root.path(),
+        "escape",
+        "config.cwd",
+        Absolute::AllowInside,
+    )
+    .expect_err("the symlink target is outside the workspace");
+
+    assert!(error.contains("resolves outside the workspace"), "{error}");
+}
+
+#[test]
+fn the_run_workspace_comes_from_the_run_slice_then_the_trigger() {
+    assert_eq!(
+        run_workspace(&json!({ "workspace": "/srv/checkout" })),
+        Some("/srv/checkout")
+    );
+    assert_eq!(
+        run_workspace(&json!({ "trigger": { "workspace": "/srv/from-trigger" } })),
+        Some("/srv/from-trigger"),
+        "a host may pin a workspace per run without editing the graph"
+    );
+    assert_eq!(
+        run_workspace(&json!({
+            "workspace": "/srv/seeded",
+            "trigger": { "workspace": "/srv/from-trigger" }
+        })),
+        Some("/srv/seeded"),
+        "the seeded run workspace wins"
+    );
+    assert_eq!(run_workspace(&json!({ "workspace": "  " })), None);
+    assert_eq!(run_workspace(&json!({})), None);
+}
+
+#[test]
+fn a_run_with_no_workspace_passes_the_directory_through() {
+    // A harness whose agents run in a remote sandbox names directories this
+    // process has never heard of; checking them locally would fail every one.
+    let resolved = resolve_node_dir(&json!({}), "/srv/checkout", "config.cwd", "agent node a")
+        .expect("no workspace, no resolution");
+
+    assert_eq!(resolved, "/srv/checkout");
+}
+
+#[test]
+fn a_resolved_directory_is_reported_with_the_node_surface() {
+    let root = workspace();
+    let run = json!({ "workspace": root.path().to_string_lossy() });
+    let error = resolve_node_dir(&run, "nope", "config.cwd", "agent node prepare")
+        .expect_err("a missing directory fails the step");
+
+    assert!(error.to_string().starts_with("agent node prepare:"), "{error}");
+}

--- a/src/workdir_tests.rs
+++ b/src/workdir_tests.rs
@@ -186,5 +186,5 @@ fn a_resolved_directory_is_reported_with_the_node_surface() {
     let error = resolve_node_dir(&run, "nope", "config.cwd", "agent node prepare")
         .expect_err("a missing directory fails the step");
 
-    assert!(error.to_string().starts_with("agent node prepare:"), "{error}");
+    assert!(error.to_string().contains("agent node prepare:"), "{error}");
 }

--- a/src/workdir_tests.rs
+++ b/src/workdir_tests.rs
@@ -6,7 +6,9 @@
 
 use serde_json::json;
 
-use super::{Absolute, resolve_dir_in_workspace, resolve_in_workspace, resolve_node_dir, run_workspace};
+use super::{
+    Absolute, resolve_dir_in_workspace, resolve_in_workspace, resolve_node_dir, run_workspace,
+};
 
 /// A workspace with a `worktrees/issue-1` directory and a file in it.
 fn workspace() -> tempfile::TempDir {
@@ -66,7 +68,10 @@ fn an_absolute_directory_is_refused_where_the_rule_is_stricter() {
     )
     .expect_err("Absolute::Refuse takes no absolute path, inside or not");
 
-    assert!(error.contains("must be relative to the workspace"), "{error}");
+    assert!(
+        error.contains("must be relative to the workspace"),
+        "{error}"
+    );
 }
 
 #[test]
@@ -110,7 +115,10 @@ fn a_directory_that_does_not_exist_fails_naming_the_path() {
     .expect_err("a missing directory fails rather than falling back to the workspace");
 
     assert!(error.contains("worktrees/issue-404"), "{error}");
-    assert!(error.contains("does not resolve inside the workspace"), "{error}");
+    assert!(
+        error.contains("does not resolve inside the workspace"),
+        "{error}"
+    );
 }
 
 #[test]
@@ -135,13 +143,9 @@ fn a_symlink_inside_the_workspace_pointing_out_of_it_is_refused() {
     let elsewhere = tempfile::tempdir().expect("tempdir");
     std::os::unix::fs::symlink(elsewhere.path(), root.path().join("escape")).expect("symlink");
 
-    let error = resolve_dir_in_workspace(
-        root.path(),
-        "escape",
-        "config.cwd",
-        Absolute::AllowInside,
-    )
-    .expect_err("the symlink target is outside the workspace");
+    let error =
+        resolve_dir_in_workspace(root.path(), "escape", "config.cwd", Absolute::AllowInside)
+            .expect_err("the symlink target is outside the workspace");
 
     assert!(error.contains("resolves outside the workspace"), "{error}");
 }

--- a/tests/agent_workdir_e2e.rs
+++ b/tests/agent_workdir_e2e.rs
@@ -1,0 +1,248 @@
+#![cfg(feature = "mock")]
+//! End-to-end tests for **where an agent step runs**.
+//!
+//! A run is pinned to one workspace, and until now every `agent` node's harness
+//! booted in it: a `cwd` on the node was accepted, persisted into the stored
+//! graph, and silently ignored. These drive the real engine to pin the opposite
+//! — that the directory an author names is the directory the harness is told
+//! about, that it may be a value an earlier node produced, and that a bad one
+//! fails the step instead of quietly falling back to the workspace.
+
+use serde_json::{Value, json};
+use tinyflows::caps::mock::{MockAgentHarness, mock_capabilities_with_agent};
+use tinyflows::compiler::compile;
+use tinyflows::engine::{RunInput, run};
+use tinyflows::model::WorkflowGraph;
+
+/// A workspace holding the worktree an issue workflow would have prepared.
+fn workspace() -> tempfile::TempDir {
+    let root = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(root.path().join("worktrees/issue-1")).expect("mkdir");
+    root
+}
+
+/// The canonical workspace path, which is what a resolved `cwd` is compared
+/// against: a temporary directory is a symlink on some platforms.
+fn canonical(root: &tempfile::TempDir) -> String {
+    root.path()
+        .canonicalize()
+        .expect("canonicalize")
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// A graph whose run is pinned to `workspace`, preparing a worktree path in one
+/// node and running an agent with `cwd` set to `cwd_config`.
+fn graph_json(workspace: &str, cwd_config: Value) -> Value {
+    json!({
+        "name": "implement",
+        "nodes": [
+            {
+                "id": "t", "kind": "trigger", "name": "start",
+                "config": { "trigger_kind": "manual", "workspace": workspace }
+            },
+            {
+                "id": "prepare", "kind": "transform", "name": "Prepare worktree",
+                "config": { "set": { "worktree": "worktrees/issue-1" } }
+            },
+            {
+                "id": "code", "kind": "agent", "name": "Implement",
+                "config": { "agent_ref": "coder", "prompt": "Implement it.", "cwd": cwd_config }
+            }
+        ],
+        "edges": [
+            { "from_node": "t", "to_node": "prepare" },
+            { "from_node": "prepare", "to_node": "code" }
+        ]
+    })
+}
+
+fn parse(graph: Value) -> WorkflowGraph {
+    serde_json::from_value(graph).expect("graph deserializes")
+}
+
+/// Runs `graph` against a harness that echoes the request it was handed.
+async fn run_graph(graph: &WorkflowGraph) -> Result<Value, String> {
+    let compiled = compile(graph).expect("compile");
+    let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+    run(&compiled, RunInput::new(Value::Null), &caps)
+        .await
+        .map(|outcome| outcome.output["nodes"]["code"]["items"][0]["json"]["json"].clone())
+        .map_err(|e| e.to_string())
+}
+
+#[tokio::test]
+async fn a_relative_cwd_resolves_against_the_run_workspace() {
+    let root = workspace();
+    let graph = parse(graph_json(&canonical(&root), json!("worktrees/issue-1")));
+
+    let request = run_graph(&graph).await.expect("run");
+
+    assert_eq!(
+        request["working_dir"],
+        json!(format!("{}/worktrees/issue-1", canonical(&root))),
+        "the harness is told the resolved directory, not the raw config string"
+    );
+}
+
+#[tokio::test]
+async fn an_absolute_cwd_inside_the_workspace_is_honored() {
+    let root = workspace();
+    let inside = format!("{}/worktrees/issue-1", canonical(&root));
+    let graph = parse(graph_json(&canonical(&root), json!(inside)));
+
+    let request = run_graph(&graph).await.expect("run");
+
+    assert_eq!(request["working_dir"], json!(inside));
+}
+
+#[tokio::test]
+async fn a_cwd_bound_to_an_earlier_nodes_output_resolves() {
+    // The whole point of the feature: the directory is one an earlier node
+    // produced, so it cannot be written literally in the graph.
+    let root = workspace();
+    let graph = parse(graph_json(
+        &canonical(&root),
+        json!("=nodes.prepare.item.worktree"),
+    ));
+
+    let request = run_graph(&graph).await.expect("run");
+
+    assert_eq!(
+        request["working_dir"],
+        json!(format!("{}/worktrees/issue-1", canonical(&root)))
+    );
+}
+
+#[tokio::test]
+async fn a_cwd_outside_the_workspace_is_refused() {
+    let root = workspace();
+    let elsewhere = tempfile::tempdir().expect("tempdir");
+    let graph = parse(graph_json(
+        &canonical(&root),
+        json!(elsewhere.path().to_string_lossy()),
+    ));
+
+    let error = run_graph(&graph).await.expect_err("the step must fail");
+
+    assert!(error.contains("resolves outside the workspace"), "{error}");
+    assert!(error.contains("agent node code"), "{error}");
+}
+
+#[tokio::test]
+async fn a_cwd_that_does_not_exist_fails_naming_the_path() {
+    let root = workspace();
+    let graph = parse(graph_json(&canonical(&root), json!("worktrees/issue-404")));
+
+    let error = run_graph(&graph).await.expect_err("the step must fail");
+
+    assert!(
+        error.contains("worktrees/issue-404"),
+        "the message names the directory: {error}"
+    );
+    assert!(
+        !error.contains("worktrees/issue-1"),
+        "and it does not quietly fall back to the workspace: {error}"
+    );
+}
+
+#[tokio::test]
+async fn a_run_with_no_workspace_passes_the_directory_through_unchanged() {
+    // Back-compat: a harness whose agents run in a sandbox names directories
+    // this process has never heard of.
+    let graph = parse(json!({
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "start", "config": { "trigger_kind": "manual" } },
+            {
+                "id": "code", "kind": "agent", "name": "Implement",
+                "config": { "agent_ref": "coder", "prompt": "go", "working_dir": "/srv/checkout" }
+            }
+        ],
+        "edges": [{ "from_node": "t", "to_node": "code" }]
+    }));
+
+    let request = run_graph(&graph).await.expect("run");
+
+    assert_eq!(request["working_dir"], json!("/srv/checkout"));
+}
+
+#[tokio::test]
+async fn a_sub_workflow_may_run_its_child_in_another_directory() {
+    let root = workspace();
+    let child = json!({
+        "name": "child",
+        "nodes": [
+            { "id": "ct", "kind": "trigger", "name": "start", "config": { "trigger_kind": "manual" } },
+            {
+                "id": "code", "kind": "agent", "name": "Implement",
+                "config": { "agent_ref": "coder", "prompt": "go", "cwd": "." }
+            }
+        ],
+        "edges": [{ "from_node": "ct", "to_node": "code" }]
+    });
+    let graph = parse(json!({
+        "name": "parent",
+        "nodes": [
+            {
+                "id": "t", "kind": "trigger", "name": "start",
+                "config": { "trigger_kind": "manual", "workspace": canonical(&root) }
+            },
+            {
+                "id": "child", "kind": "sub_workflow", "name": "Child",
+                "config": { "workflow": child, "workspace": "worktrees/issue-1" }
+            }
+        ],
+        "edges": [{ "from_node": "t", "to_node": "child" }]
+    }));
+
+    let compiled = compile(&graph).expect("compile");
+    let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+    let outcome = run(&compiled, RunInput::new(Value::Null), &caps)
+        .await
+        .expect("run");
+    let child_state = &outcome.output["nodes"]["child"]["items"][0]["json"];
+
+    assert_eq!(
+        child_state["run"]["workspace"],
+        json!(format!("{}/worktrees/issue-1", canonical(&root))),
+        "the child run is pinned to the directory the node named"
+    );
+    assert_eq!(
+        child_state["nodes"]["code"]["items"][0]["json"]["json"]["working_dir"],
+        json!(format!("{}/worktrees/issue-1", canonical(&root))),
+        "and the child's agent resolves `cwd` against it"
+    );
+}
+
+#[tokio::test]
+async fn a_sub_workflow_workspace_may_not_escape_the_parents() {
+    let root = workspace();
+    let elsewhere = tempfile::tempdir().expect("tempdir");
+    let child = json!({
+        "nodes": [{ "id": "ct", "kind": "trigger", "name": "start", "config": { "trigger_kind": "manual" } }],
+        "edges": []
+    });
+    let graph = parse(json!({
+        "nodes": [
+            {
+                "id": "t", "kind": "trigger", "name": "start",
+                "config": { "trigger_kind": "manual", "workspace": canonical(&root) }
+            },
+            {
+                "id": "child", "kind": "sub_workflow", "name": "Child",
+                "config": { "workflow": child, "workspace": elsewhere.path().to_string_lossy() }
+            }
+        ],
+        "edges": [{ "from_node": "t", "to_node": "child" }]
+    }));
+
+    let compiled = compile(&graph).expect("compile");
+    let caps = mock_capabilities_with_agent(MockAgentHarness::new());
+    let error = run(&compiled, RunInput::new(Value::Null), &caps)
+        .await
+        .expect_err("the child must not run outside the parent's workspace")
+        .to_string();
+
+    assert!(error.contains("resolves outside the workspace"), "{error}");
+    assert!(error.contains("sub_workflow node child"), "{error}");
+}

--- a/tests/fuzz_interception.proptest-regressions
+++ b/tests/fuzz_interception.proptest-regressions
@@ -11,3 +11,4 @@ cc 201cea089acc9cbb4ed3a0bf98e20f57b1e671b9fb6d8636084a4c5a06abd47c # shrinks to
 cc 60dcc55b51c47d53d5c569e160e47326be3516ad1444256c44ef6a21f1a3a708 # shrinks to shape = Nested(Branch(Spawned { tasks: 1, release: "all", n: 2 }, Loop { max_iter: 3, body: Spawned { tasks: 3, release: "all", n: 1 } }))
 cc c9826493d112ad19cdf5822aac757e9b93306189414049540997db7018e2e39c # shrinks to shape = Loop { max_iter: 3, body: Spawned { tasks: 1, release: "all", n: 1 } }
 cc 10f774fdc90ae37d8987e735b588e777bd8c9ae98bb4f5995d03ab995647ca66 # shrinks to shape = Fanout([Linear(2), Loop { max_iter: 2, body: Linear(1) }, Fanout([Linear(1), Linear(1), Spawned { tasks: 2, release: "all", n: 3 }])])
+cc cf8866a210faf9d603c145926ae0bd44da0d0e209696879b5ac903dfe7fd0d47 # shrinks to shape = Fanout([Loop { max_iter: 1, body: Linear(0) }, Nested(Spawned { tasks: 3, release: "all", n: 2 })])

--- a/wiki/Node-Catalog.md
+++ b/wiki/Node-Catalog.md
@@ -70,14 +70,41 @@ traits](Capability-Traits).
 
 | Node | Purpose | Ports / config gist |
 |------|---------|---------------------|
-| `agent` | Runs an LLM agent turn | Sub-ports `chat_model` / `memory` / `tool` / `output_parser`; config `prompt`, `model`, … — via `LlmProvider` |
+| `agent` | Runs an LLM agent turn | Sub-ports `chat_model` / `memory` / `tool` / `output_parser`; config `prompt`, `model`, `cwd`, … — via `LlmProvider` |
 | `tool_call` | Invokes one specific integration action | Config `slug`, `args` — via `ToolInvoker` |
 | `http_request` | Outbound HTTP request | Config `method`, `url`, `headers`, `query`, `body` — via `HttpClient` |
 | `code` | Runs sandboxed user code | Config `language` (`javascript`/`python`), `source` — via `CodeRunner` |
 | `shell` | Runs a shell script, inline or from a file | Config `source` **or** `script_path`, plus `interpreter` (`sh`/`bash`), `cwd`, `env` — via `ShellRunner` |
 | `output_parser` | Parses/validates an agent's output into a structured shape | May use `LlmProvider` for auto-fixing; can nest as a sub-agent |
 | `approval` | Puts a subject in front of a **human** and routes on approve/reject | Out `approved` / `rejected` / `timeout`; config `subject`, `subject_kind`, `title`, `prompt`, `assignees`, `wait_mode`, `on_reject`, `on_timeout` (`error` default / `reject` / `route` — `route` is required to reach the `timeout` port) — via `ApprovalProvider` |
-| `sub_workflow` | Runs another workflow as a nested sub-graph | Config: exactly one of `workflow` (inline) / `workflow_id`; optional `inputs` map for the child's declared inputs |
+| `sub_workflow` | Runs another workflow as a nested sub-graph | Config: exactly one of `workflow` (inline) / `workflow_id`; optional `inputs` map for the child's declared inputs, optional `workspace` to run the child elsewhere |
+
+### Where a step runs
+
+A run is pinned to one **workspace** — the trigger's `config.workspace`, or a
+`workspace` key on the trigger payload for a host that pins one per run. Every
+directory a node names resolves against it:
+
+- an `agent` node's `cwd` (`working_dir` is the older spelling of the same key),
+- a `shell` node's `cwd`, and a script step's `args.cwd`,
+- a `sub_workflow` node's `workspace`, which re-pins the **child run** — the
+  child inherits the parent's otherwise.
+
+One rule for all of them: a relative path is joined to the workspace, an
+absolute one is allowed only if it resolves inside it (symlinks followed), and a
+directory that is missing or is not a directory **fails the step** rather than
+falling back to the workspace. Every one of them is `=`-bindable, which is the
+point — `"cwd": "=nodes.prepare.item.json.worktree"` runs the step in a
+directory an earlier node created.
+
+A run with **no** workspace resolves nothing: the string reaches the harness
+verbatim, as it always has, because a host whose agents run in a remote sandbox
+names directories this process has never heard of.
+
+A directory key a node does not read — `workdir` on an `agent` node, `cwd` on a
+`tool_call` node — is a **validation error**, not a silent no-op. Being able to
+write down where a step runs and have it ignored is the failure this whole seam
+exists to remove.
 
 The capability-backed integration nodes (`agent`, `tool_call`, `http_request`)
 resolve `=` expressions anywhere in their config against the `{ item, items, run }`


### PR DESCRIPTION
## What

An `agent` node can now say **where** its harness runs, and a `sub_workflow` node can re-pin the workspace of the child run.

- `cwd` on an `agent` node (`working_dir` kept as the older spelling of the same key).
- `workspace` on a `sub_workflow` node, which re-pins the child run; the child inherits the parent's otherwise.
- Both are `=`-bindable, which is the point: `"cwd": "=nodes.prepare.item.json.output.worktree"` runs the step in a directory an earlier node just created.
- The containment rule a shell step's `args.cwd` already obeyed is hoisted into one shared module (`src/workdir.rs`) so there is exactly one of them: a relative path joins the workspace, an absolute one is allowed only if it resolves inside it (symlinks followed), and a missing path or a non-directory **fails the step** rather than falling back to the workspace.
- A run with no workspace resolves nothing and passes the value through verbatim, for hosts whose agents run in a remote sandbox.
- A directory key a node does **not** read — `workdir` on an `agent` node, a top-level `cwd` on a `tool_call` node — is now a validation error rather than being accepted, persisted and ignored.

## Why

A run is pinned to one workspace at launch, and until now every agent step's harness booted in it. A `cwd` on the node was accepted into the stored graph and silently ignored.

This was found empirically against a live host, not by reading code:

1. An `agent` node with `cwd` set to a prepared worktree, asked to report `pwd` and `git rev-parse --abbrev-ref HEAD`, run with the workspace set to the parent checkout. It reported the **workspace** and branch `main`, not the worktree.
2. The same node with `workspace`, `working_dir` and `workdir` all set at once. Same result — all four ignored, with no error anywhere.
3. A `sub_workflow` node carrying a `workspace`. The child's agent still reported the parent's workspace.

The motivating case: an issue-implementation workflow prepares a git worktree in one node and wants the coding harness to boot inside it. It could not, so the harness started in the primary checkout on the base branch and the workflow had to rely on prose in the prompt telling the agent to `cd`. Anything acting on the process working directory — a PostToolUse auto-commit hook, for one — then operated against the primary checkout on `main` instead of the feature worktree.

The silent acceptance is why the validation error is part of this change. Being able to write down where a step runs and have it ignored is the failure this seam exists to remove.

## Tests

`tests/agent_workdir_e2e.rs` drives the real engine (gated on `mock`, as 38 of the 43 test files here are):

- `a_relative_cwd_resolves_against_the_run_workspace`
- `an_absolute_cwd_inside_the_workspace_is_honored`
- `a_cwd_outside_the_workspace_is_refused`
- `a_cwd_that_does_not_exist_fails_naming_the_path`
- `a_cwd_bound_to_an_earlier_nodes_output_resolves`
- `a_sub_workflow_may_run_its_child_in_another_directory`
- `a_sub_workflow_workspace_may_not_escape_the_parents`
- `a_run_with_no_workspace_passes_the_directory_through_unchanged`

Plus unit coverage in `src/workdir_tests.rs` and `src/validate/workdir_tests.rs`.

## Commands run

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 1157 passed, 0 failed
- `cargo test --all-features` — 1401 passed across 46 binaries, 0 failed

## Notes

Rebased onto current `upstream/main` (the branch point was 160 commits behind). Three conflicts resolved by keeping both sides: the `approval` node's catalog row and CHANGELOG entries alongside this branch's workspace documentation.

One commit from the original branch was dropped deliberately: `chore(tests): remove stale proptest regression file` deleted 7 checked-in `fuzz_interception` proptest seeds, which is regression coverage unrelated to this change. All 8 seeds are retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workspace-aware working-directory support for agent and sub-workflow nodes.
  - Supports relative paths, validated absolute paths within the workspace, expressions, and workspace inheritance for child workflows.
  - Added safeguards against path traversal, symlink escapes, missing directories, and invalid locations.

- **Bug Fixes**
  - Working-directory settings now resolve consistently across supported execution paths.
  - Added clear validation errors for unsupported directory configuration keys.

- **Documentation**
  - Documented workspace and working-directory configuration, resolution rules, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->