### PR TITLE
fix(tinyflows): restore compat and preflight module declarations dropped in merge

### DIFF
--- a/crates/tinyflows/src/lib.rs
+++ b/crates/tinyflows/src/lib.rs
@@ -57,6 +57,14 @@ pub mod migrate;
 pub mod model;
 pub mod nodes;
 pub mod observability;
+/// Proving a graph's outbound arguments can resolve, by running it against
+/// mocks before an author is allowed to save it.
+///
+/// Behind `mock` because that is where the schema-aware doubles it runs on
+/// live — the check *is* a mock run, so there is nothing to compile without
+/// them.
+#[cfg(any(test, feature = "mock"))]
+pub mod preflight;
 /// Stored workflows and their run history: the durable model around a graph,
 /// and a file-backed store for it. Behind the `store` feature.
 #[cfg(any(test, feature = "store"))]

--- a/crates/tinyflows/src/lib.rs
+++ b/crates/tinyflows/src/lib.rs
@@ -24,6 +24,9 @@
 pub mod bindings;
 pub mod caps;
 pub mod catalog;
+/// Topologies this engine's fan-in lowering cannot execute safely, refused
+/// before a run rather than surfacing as dropped data or a hung barrier.
+pub mod compat;
 pub mod compiler;
 pub mod data;
 /// Reading a run's steps for the failures a green outcome hides: null bindings,


### PR DESCRIPTION
## Summary

- Merge commit `fb946d6` ("Merge remote-tracking branch 'refs/remotes/upstream/main' into pr/78") silently dropped the `pub mod compat;` and `#[cfg(any(test, feature = "mock"))] pub mod preflight;` declarations from `crates/tinyflows/src/lib.rs`, as collateral damage of a botched unrelated-history merge (the merge's second parent, `16aad9a`, came in via a conflict resolution that regenerated `lib.rs` from a base treated as empty — note the `0000000` base blob in `git show fb946d6 -- crates/tinyflows/src/lib.rs`).
- The commit immediately before the merge (`7601283`) still declared both modules. The implementation files (`compat.rs`, `compat_tests.rs`, `preflight.rs`, `preflight_tests.rs`) were **never deleted** and still compile — only the `pub mod` declarations vanished from `lib.rs`.
- As a result, **tinyflows v0.8.1 shipped without this public API**, even though the crate still ships the implementation. This broke downstream consumers that import `tinyflows::compat::…` and `tinyflows::preflight::…` (e.g. `openhuman`).
- This PR restores the two dropped declarations verbatim (doc comments and cfg gates matching the pre-merge state exactly), back in their original position in `lib.rs`.

## Also investigated: `browser` and `companion`

The same merge also dropped `pub mod browser` and `pub mod companion` (both `#[cfg(feature = "chrome-extension")]`). Unlike `compat`/`preflight`, these were **not** accidental collateral damage — their source files (`browser.rs`, `companion.rs`) no longer exist anywhere in history. They were deliberately removed by PR #79 ("remove-chrome-extension", commit `4d6b874` "refactor: remove Chrome workflow companion"), which is the merge's other parent (`16aad9a`). This PR intentionally leaves `browser`/`companion` untouched.

## Test plan

- [x] `git show fb946d6 -- crates/tinyflows/src/lib.rs` — confirmed the diff drops both declarations against a `0000000` base
- [x] `git show 7601283:crates/tinyflows/src/lib.rs | grep -n "pub mod"` — confirmed both declarations existed pre-merge
- [x] Confirmed `compat.rs`, `compat_tests.rs`, `preflight.rs`, `preflight_tests.rs` still exist on `upstream/main` and are unreferenced by any other `mod` declaration
- [x] Confirmed `browser.rs`/`companion.rs` do not exist anywhere in history (removed by PR #79) — left alone
- [x] `cargo check -p tinyflows --features mock`
- [x] `cargo check --workspace --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow compatibility checks to identify unsupported fan-in configurations before execution.
  * Added preflight validation for outbound argument resolution before workflows are saved.
* **Bug Fixes**
  * Improved safeguards against invalid workflow configurations reaching execution or persistence.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->